### PR TITLE
docs: update branch strategy - main holds latest state

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -110,14 +110,10 @@ bun test                 # Run all tests
 
 ## Branch Strategy
 
-**Cumulative chain:** each stage branches from the previous stage, not from main. Main is a bare shell (template, config, master plan) -- it never receives stage merges.
+**Cumulative chain:** each stage branches from the previous stage. Main holds the latest complete state. Stage branches are permanent snapshots for readers.
 
 ```bash
-# Starting a new stage
-git checkout stage/N-1-name && git checkout -b stage/N-name
-
 # Diff commands for readers
-git diff main..stage/1-dispatch              # What stage 1 adds to the shell
 git diff stage/1-dispatch..stage/2-dag       # What stage 2 adds
 git diff stage/2-dag..stage/3-full           # What stage 3 adds
 ```

--- a/specs/master-plan.md
+++ b/specs/master-plan.md
@@ -278,10 +278,10 @@ Each gets its own detailed plan before implementation. See stage descriptions in
 
 ## Branch Strategy - Cumulative Chain
 
-**Branch model: cumulative chain.** Each stage branches from the previous stage (not from main). This means each branch contains everything from prior stages plus its own additions. Branches are never deleted -- they serve as permanent, runnable snapshots. Main stays as a clean shell (template baseline, config, master plan) -- it never receives stage merges.
+**Branch model: cumulative chain.** Each stage branches from the previous stage. Main holds the latest complete state. This means each branch contains everything from prior stages plus its own additions. Branches are never deleted -- they serve as permanent, runnable snapshots.
 
 ```
-main (bare shell -- no stage implementations)
+main (latest complete state)
   |
   +-- stage/1-dispatch
         |
@@ -304,19 +304,19 @@ main (bare shell -- no stage implementations)
 
 ### What lives on main
 
-Main is the bare scaffold -- a "table of contents," not a chapter:
+Main holds the latest complete state -- all stage implementations merged when complete:
 
-- Starter template (`package.json`, `tsconfig.json`, `biome.json`, CI config)
+- Full project config (`package.json`, `tsconfig.json`, `biome.json`, CI config)
 - `specs/master-plan.md` (this file)
-- Minimal `CLAUDE.md` pointing readers to stage branches
-- **No** stage implementations, agents, skills, or pattern docs
+- `CLAUDE.md` with full project conventions
+- All stage implementations, agents, skills, and pattern docs
 
 ### Rules for starting a new stage
 
 1. Checkout the previous stage branch: `git checkout stage/N-1-name`
 2. Create the new branch: `git checkout -b stage/N-name`
 3. Implement the stage
-4. Push the branch -- **never merge to main**
+4. Push the branch -- merge to main when complete
 
 ### Branch protection
 
@@ -352,5 +352,5 @@ Each diff shows exactly what a stage introduces -- no noise from unrelated chang
 - **Resume on retry** -- `resume: agentId` preserves builder's prior context
 - **Spec re-read at each wave** -- context compaction can evict the plan
 - **Prototype before plugin** -- iterate fast, prove HOP works, then extract
-- **Cumulative branches, clean main** -- main is a shell, each stage branches from the previous one. Optimizes for readers (checkout-and-run, progressive diffs) over maintainers (cherry-pick cascade on fixes). Acceptable tradeoff for a bounded 9-stage learning repo
+- **Cumulative branches, main holds latest state** -- each stage branches from the previous one, merged to main when complete. Optimizes for readers (checkout-and-run, progressive diffs) over maintainers (cherry-pick cascade on fixes). Acceptable tradeoff for a bounded 9-stage learning repo
 - **Pattern docs grow progressively** -- each stage adds new patterns to `docs/patterns/`


### PR DESCRIPTION
## Summary

- Remove "bare shell" language from CLAUDE.md and master-plan.md
- Main now described as holding the latest complete state
- Stage branches remain as permanent snapshots for readers
- "never merge to main" changed to "merge to main when complete"

## Verification

- `bun run validate` passes
- `grep -r "bare shell" .` returns no matches
- `grep -r "never merge to main" .` returns no matches

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated branch strategy documentation: Main branch now described as maintaining the latest complete project state.
  * Modified workflow guidelines: stage branches now merge to main upon completion instead of remaining separate.
  * Expanded branch protection and permanent snapshot documentation with enhanced stage progression diagrams.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->