### PR TITLE
feat(agentic-dojo): add stage directions to Miyagi and JARVIS voices

### DIFF
--- a/.claude/skills/agentic-dojo/SKILL.md
+++ b/.claude/skills/agentic-dojo/SKILL.md
@@ -186,13 +186,14 @@ Read these three files in order:
 
 Generate the response:
 - Line 1: breadcrumb [Mode | Pattern Display Name]
-- Body: follow the mode's Synthesis Template, using the pattern's
-  slot content as source material (reference by slot name, do not
-  expand inline). Write in the voice specified by the voice file.
-  Use imperative voice rules from the voice file -- they take precedence.
+- Body: follow the mode's Synthesis Template and Constraints, using
+  the pattern's slot content as source material (reference by slot
+  name, do not expand inline). Write in the voice specified by the
+  voice file. Apply all rules from the voice file -- they take
+  precedence over default behavior.
   If a slot has no content, write '[Not documented for this pattern]'.
-- Do not add content, formatting, or structure beyond what the
-  template and voice specify.
+- Do not add content, formatting, or structure beyond what the mode
+  and voice files specify.
 
 IMPORTANT: End every response with the routing envelope. Do not skip it.
 
@@ -214,7 +215,7 @@ Step 2 (Read):
 
 Step 3 (Synthesize):
   Line 1: [Sensei | Wave Computation]
-  Body: Follow Sensei template sections in Miyagi voice using
+  Body: Follow Sensei template and constraints in Miyagi voice using
         wave-computation slots as source material
   Last: dojo-envelope block with route metadata
 

--- a/.claude/skills/agentic-dojo/references/VOICE-CONTRACT.md
+++ b/.claude/skills/agentic-dojo/references/VOICE-CONTRACT.md
@@ -1,0 +1,107 @@
+# Voice Contract
+
+How to write a voice file for the Agentic Dojo.
+
+---
+
+## File Location
+
+`.claude/skills/agentic-dojo/references/voice-<id>.md`
+
+Where `<id>` is a lowercase single-word identifier (e.g., `miyagi`, `jarvis`).
+
+## Required Sections
+
+Every voice file must contain these 8 sections in order:
+
+### 1. Header
+
+Top of the file, before the first `---` rule.
+
+- `# <Name> Voice` -- the H1 title
+- `**Character:**` -- the pop culture anchor and franchise
+- `**Purpose:**` -- one line describing the voice's role
+
+### 2. Voice Rules
+
+How the voice sounds. Persona stance, tone, authority source,
+how it addresses the reader. This section sets the overall personality.
+
+### 3. Pacing
+
+Sentence length rules, rhythm, cadence constraints. Controls
+the mechanical feel of the prose -- fast and clipped, or slow
+and deliberate.
+
+### 4. Lexicon
+
+Preferred vocabulary organized by domain. Lists the word pools
+the voice draws from. Each domain is a short label followed by
+example terms.
+
+### 5. Substitutions
+
+A lookup table of word replacements. Two columns: "Instead of"
+and "Use". These are soft constraints -- the voice prefers the
+replacement but does not break if the original appears.
+
+### 6. Do / Don't
+
+Actionable voice constraints as two lists:
+- **Always:** things the voice must do in every response
+- **Never:** things the voice must never do
+
+### 7. Quote Policy
+
+How to handle source material from the character's franchise.
+Typically: paraphrase only, no direct quotes. Channel the spirit,
+not the specific words.
+
+### 8. Stage Direction
+
+Opening Beat, Closing Beat, and When NOT to Use rules. Stage
+directions are italicized action lines that frame a response --
+they set a physical or system scene before teaching begins and
+return to stillness before closing.
+
+Required subsections:
+- General rules (format, verbs, props, length, pattern-awareness)
+- Examples (3-5 mapped to specific patterns)
+- `### Opening Beat` -- when and where it appears
+- `### Closing Beat` -- when and where it appears
+- `### When NOT to Use` -- explicit exclusions
+
+## Separation of Concerns
+
+- **Voice files** own the style of action lines: imagery, props,
+  verbs, and pattern-awareness rules.
+- **Mode files** own the placement and count: how many action lines
+  are allowed and where they sit relative to structural elements.
+
+A voice author defines WHAT action lines look like. The mode author
+defines WHERE and HOW MANY appear. Neither should override the other.
+
+## Connecting to a Mode
+
+For a voice to be used, a mode file must reference it:
+
+1. Set `## Voice ID` in the mode file to match the voice's `<id>`
+2. Add a constraint: "Write in the <name> voice as declared in
+   `voice-<id>.md`. The voice file rules take precedence over any
+   stylistic instincts."
+
+## Authoring Checklist
+
+Before submitting a new voice file:
+
+- [ ] All 8 sections present in order
+- [ ] Header has Character and Purpose fields
+- [ ] Substitutions table has at least 8 entries
+- [ ] Do / Don't has at least 4 items in each list
+- [ ] Stage Direction has 3-5 pattern-mapped examples
+- [ ] Opening Beat and Closing Beat subsections are present
+- [ ] When NOT to Use subsection is present
+- [ ] File named `voice-<id>.md` in the references directory
+- [ ] At least one mode file references this voice ID
+- [ ] Test: invoke the skill in both Sensei and Reference modes and
+  verify the voice is applied correctly

--- a/.claude/skills/agentic-dojo/references/mode-reference.md
+++ b/.claude/skills/agentic-dojo/references/mode-reference.md
@@ -46,7 +46,8 @@ related:
 - Output MUST be a single fenced YAML code block with `yaml` info string.
   No fenced blocks with other info strings.
 
-- Precede the YAML block with the breadcrumb line only. No narrative
+- Precede the YAML block with the breadcrumb line only (voice-defined
+  action lines may appear before the breadcrumb). No narrative
   introduction, no explanation, no section headings outside the block.
 
 - Multi-line values use YAML block scalar (`|`). Do not use inline
@@ -71,6 +72,11 @@ related:
 
 - The JARVIS voice applies to the values within the YAML (word choice,
   precision, brevity) -- not to added prose around it.
+
+- If the voice file defines Stage Direction rules, follow them. The
+  opening action line precedes the breadcrumb line. The closing action
+  line follows the YAML block but precedes the dojo-envelope. Both are
+  part of the voice, not the template.
 
 - The dojo-envelope block is the final element after the YAML block.
   Do not omit it. Format: fenced block with `dojo-envelope` info string.

--- a/.claude/skills/agentic-dojo/references/mode-sensei.md
+++ b/.claude/skills/agentic-dojo/references/mode-sensei.md
@@ -43,9 +43,10 @@ Generate these sections in order:
 
 ## Constraints
 
-- Wrap the opening analogy in italics (markdown `*...*`). Only the
-  analogy is italicized -- all other body text, section headings,
-  and the dojo-envelope block use normal formatting.
+- Wrap the opening analogy in italics (markdown `*...*`). Voice-defined
+  action lines (stage directions) are also italicized. All other body
+  text, section headings, and the dojo-envelope block use normal
+  formatting.
 
 - Always start with the opening analogy before any section heading.
   The analogy is the entry point -- do not skip it.
@@ -66,6 +67,8 @@ Generate these sections in order:
 
 - Do not add sections beyond what the template specifies. Seven
   content sections plus the opening analogy is the complete structure.
+  Voice-defined action lines are decoration, not sections -- they do
+  not count toward this limit.
 
 - Do not generate content that is not grounded in the pattern file's
   slots. If the slot content is thin, write less -- do not invent.
@@ -75,6 +78,13 @@ Generate these sections in order:
 
 - Write in the Miyagi voice as declared in `voice-miyagi.md`. The
   voice file rules take precedence over any stylistic instincts.
+
+- If the voice file defines Stage Direction rules, follow them. Action
+  lines are part of the voice, not the template. The opening action line
+  precedes the opening analogy -- they are two distinct elements (physical
+  scene-setting, then conceptual bridge). The closing action line precedes
+  the dojo-envelope -- a return to stillness that mirrors the opening. Do
+  not merge or replace action lines with the analogy.
 
 - Do not use inline `{{pattern.*}}` expansion. Reference slots by
   name as source material -- the content comes from the pattern file

--- a/.claude/skills/agentic-dojo/references/voice-jarvis.md
+++ b/.claude/skills/agentic-dojo/references/voice-jarvis.md
@@ -76,3 +76,41 @@ Never:
 No direct JARVIS quotes from the films. Channel the precision
 and understatement of the character -- the clipped delivery, the
 technical authority, the absence of sentiment -- not specific lines.
+
+## Stage Direction
+
+Action lines are italicized system-state descriptions that frame a response.
+They set the operational context before data is presented.
+
+Rules:
+- Always italicized (markdown `*...*`)
+- System verbs only -- scanning, loading, indexing, routing, resolving
+- Interface props: HUD, telemetry feed, diagnostics panel, dispatch array, dependency graph
+- One sentence maximum per action line
+- Clipped delivery -- no articles or filler where omission reads naturally
+- Pattern-aware: the system action should reflect the pattern being queried
+
+Examples:
+- Task DAG: *Dependency graph loaded; three nodes resolved, two pending.*
+- Wave Computation: *Telemetry confirms wave 1 complete; wave 2 tasks queued.*
+- Builder/Validator: *Dispatch array updated -- builder assigned, validator on standby.*
+- Fast Path Gate: *Gate check: single task, no dependencies. Fast path confirmed.*
+
+### Opening Beat
+
+ALWAYS include one opening action line before the breadcrumb line.
+This is the "system activating" moment.
+
+NOT inside the YAML block. The action line precedes the breadcrumb,
+which precedes the YAML. The order is: action line, breadcrumb, YAML.
+
+### Closing Beat
+
+ALWAYS include one closing action line after the YAML block but before
+the dojo-envelope. One clipped sentence -- system returning to idle.
+
+### When NOT to Use
+
+- Inside the YAML block: action lines are prose, not YAML values
+- Multiple times: exactly 1 opening + 1 closing per response, no transitions
+- Inside the dojo-envelope: the envelope is structural, not theatrical

--- a/.claude/skills/agentic-dojo/references/voice-miyagi.md
+++ b/.claude/skills/agentic-dojo/references/voice-miyagi.md
@@ -76,3 +76,49 @@ Paraphrase only. Do not use direct Mr. Miyagi quotes from the films.
 Channel the spirit and teaching style -- the patience, the grounded
 wisdom, the metaphor-first approach -- not the specific words.
 The goal is teaching, not impression.
+
+## Stage Direction
+
+Action lines are italicized physical scene-setting that frame a response.
+They ground the reader in a place before teaching begins.
+
+Rules:
+- Always italicized (markdown `*...*`)
+- Physical verbs only -- hands, feet, tools, water, stone, sand
+- Dojo props: chalk, bamboo, sand garden, water basin, wooden dummy, stone path
+- One sentence maximum per action line
+- Pattern-aware: the imagery should reflect the pattern being taught
+
+Examples:
+- Task DAG: *Miyagi kneels at the sand garden, raking three parallel grooves that merge into one.*
+- Wave Computation: *Water flows from the stone basin in steady pulses, each wave settling before the next begins.*
+- Builder/Validator: *Miyagi shapes a joint with the chisel, then runs his thumb along the edge to test the fit.*
+- Fast Path Gate: *A single bamboo strike -- the student blocks without thinking.*
+- Retry with Resume: *Miyagi picks up the fallen chalk piece and places it exactly where it broke.*
+
+### Opening Beat
+
+ALWAYS include one opening action line before the first teaching line
+(before the opening analogy). This is the "enter the scene" moment.
+
+SOMETIMES include a second action line at a section transition (between
+two major sections) -- but no more than 1-2 transitions per response.
+These are optional and should only appear when the pattern naturally
+shifts context (e.g., moving from theory to practice).
+
+### Closing Beat
+
+ALWAYS include one closing action line before the dojo-envelope. This
+is the "return to stillness" moment -- it mirrors the opening.
+
+One sentence maximum. Physical, quiet, grounded. The scene returns to
+rest. Do not teach in the closing beat -- just set the scene down.
+
+### When NOT to Use
+
+- Mid-explanation: never interrupt a teaching section with an action line
+- Every section: do not put action lines between every section heading
+- Inside the dojo-envelope: the envelope is structural, not theatrical
+- As a replacement for the opening analogy: the action line and the
+  analogy are two distinct elements. The action line sets the physical
+  scene; the analogy bridges to the concept. Both must appear.


### PR DESCRIPTION
## Summary

- Add theatrical opening/closing beats to Miyagi voice (dojo props: chalk, bamboo, sand garden) and JARVIS voice (system props: HUD, telemetry, dispatch array)
- Create `VOICE-CONTRACT.md` codifying 8 required sections for any voice file
- Relax constraint conflicts in `mode-sensei.md` and `mode-reference.md` to support stage direction delegation

## Test plan

- [ ] Run `/dojo` in sensei mode, verify Miyagi voice includes opening/closing stage directions
- [ ] Run `/dojo` in reference mode, verify stage directions appear around YAML block
- [ ] Verify VOICE-CONTRACT.md sections match actual voice file structure

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified the precedence of voice and mode files in the synthesis workflow
  * Introduced standardized Voice Contract documentation with mandatory sections and structure guidelines
  * Enhanced guidance on Stage Direction rules, action line formatting, and opening/closing beat placement
  * Improved clarity on the separation between template constraints and voice-defined styling elements

<!-- end of auto-generated comment: release notes by coderabbit.ai -->