### PR TITLE
feat(dojo,advisor): smarter routing v2 with compare mode and context resolution

### DIFF
--- a/.claude/skills/agentic-dojo/SKILL.md
+++ b/.claude/skills/agentic-dojo/SKILL.md
@@ -13,7 +13,7 @@ description: >-
   prompts, builder-validator, spec files, fast path, iterative refinement,
   parallel execution, browser validation, or visual retry loops.
   Also use when an agent queries for pattern guidance.
-argument-hint: "e.g. 'explain wave computation' or 'lookup retry'"
+argument-hint: "e.g. 'explain wave computation', 'compare wave dag', or '--context-pattern=task-dag'"
 allowed-tools: Read, Glob, Grep
 hooks:
   Stop:
@@ -22,11 +22,13 @@ hooks:
           prompt: >-
             Check if the assistant's response contains a fenced code block
             with the info string `dojo-envelope`. The block must contain
-            YAML with at least these fields: mode_selected, pattern_selected,
-            route_reason. If the envelope block is missing or incomplete,
-            respond with STOP_REASON: "Response is missing the required
-            dojo-envelope block. Add it before finishing." If the envelope
-            is present and valid, allow the response.
+            YAML with at least these fields: mode_selected, route_reason,
+            and either pattern_selected or patterns_selected (both accepted
+            during the v2 compatibility window). If the envelope block is
+            missing or incomplete, respond with STOP_REASON: "Response is
+            missing the required dojo-envelope block. Add it before
+            finishing." If the envelope is present and valid, allow the
+            response.
 ---
 
 # Agentic Dojo
@@ -53,8 +55,9 @@ Zero-state (max 12 lines):
 Agentic Dojo -- pattern knowledge for orchestration
 
 Modes:
-  explain <pattern>    Sensei teaches the concept (default)
-  lookup <pattern>     Quick reference with structured output
+  explain <pattern>           Sensei teaches the concept (default)
+  lookup <pattern>            Quick reference with structured output
+  compare <pattern> <pattern> Side-by-side comparison of two patterns
 
 Patterns:
   builder-validator    dispatch-loop       higher-order-prompt
@@ -68,6 +71,11 @@ Patterns:
 Examples:
   /dojo explain wave computation    (short forms: wave, dag, spec, hop...)
   /dojo lookup retry-with-resume
+  /dojo compare wave dag
+
+After the reserved-keyword check, read `references/query-classifier.md`
+to classify query_type (single, compare, follow-up, disambiguation).
+When query_type = follow-up, also read `references/context-resolution.md`.
 
 ### Mode Detection
 
@@ -153,9 +161,11 @@ check if a pattern was discussed in the preceding conversation turns.
 
 | Condition | Message | Behavior |
 |-----------|---------|----------|
-| Unknown pattern | `Pattern "{input}" not found. Available: {list}. Did you mean "{closest}"?` | If input prefixes exactly one slug or alias, suggest it. Otherwise list all without a specific suggestion |
-| Unknown mode | `Mode "{input}" not recognized. Available modes: explain (sensei), lookup (reference).` | Show both user-facing and internal names |
-| Multiple patterns detected | `Multiple patterns detected: {list}. Which one would you like?` | List matches and ask user to pick. Do not auto-select |
+| Unknown pattern | `Pattern "{input}" not found. Available: {list}. Did you mean "{closest}"? Tip: try /advisor for recommendations.` | If input prefixes exactly one slug or alias, suggest it. Otherwise list all |
+| Unknown mode | `Mode "{input}" not recognized. Available modes: explain (sensei), lookup (reference), compare.` | Show all modes |
+| 2 explicit patterns (slug/alias) | Route to compare mode | Do not error -- intentional compare |
+| 3+ explicit patterns (slug/alias) | `You named {n} patterns. Compare supports 2 at a time. Which pair for compare, which one for explain or lookup?` | List the detected patterns |
+| Compare with same pattern twice | `Cannot compare a pattern with itself. Try: /dojo explain <pattern>` | Hard error, no output |
 | Missing synthesis slot | `[Not documented for this pattern]` | Inline substitution, do not fail |
 
 If no pattern in the alias table, keyword table, or conversation
@@ -168,56 +178,42 @@ no pattern matches.
 - Never writes code, creates files, or modifies the codebase
 - Never executes scripts or runs commands
 - Does not replace the orchestrator skill -- this teaches patterns, that executes them
-- Does not compare patterns side-by-side (v2 consideration)
 
 ## Step 2: Read
 
-Read these three files in order:
+Read these files in order based on detected mode:
 
-1. The mode file matching the detected mode:
-   - Sensei: `references/mode-sensei.md` -- note the Voice ID
-   - Reference: `references/mode-reference.md` -- note the Voice ID
-2. The pattern file from the File column in the keyword table above
-3. The voice file matching the Voice ID from the mode file:
-   - miyagi: `references/voice-miyagi.md`
-   - jarvis: `references/voice-jarvis.md`
+1. Sensei or Reference mode:
+   - Mode file: `references/mode-sensei.md` or `references/mode-reference.md` -- note the Voice ID
+   - Pattern file from the File column in the keyword table above
+   - Voice file matching the Voice ID: `references/voice-miyagi.md` or `references/voice-jarvis.md`
+2. Compare mode:
+   - `references/mode-compare.md` -- note the Voice ID (JARVIS)
+   - Pattern file for pattern A (from keyword table)
+   - Pattern file for pattern B (from keyword table)
+   - `references/voice-jarvis.md`
 
 ## Step 3: Synthesize
 
 Generate the response:
 - Line 1: breadcrumb [Mode | Pattern Display Name]
-- Body: follow the mode's Synthesis Template and Constraints, using
-  the pattern's slot content as source material (reference by slot
-  name, do not expand inline). Write in the voice specified by the
-  voice file. Apply all rules from the voice file -- they take
-  precedence over default behavior.
+- Body: follow the mode's Synthesis Template, using the pattern's
+  slot content as source material (reference by slot name, do not
+  expand inline). Write in the voice specified by the voice file.
+  Use imperative voice rules from the voice file -- they take precedence.
   If a slot has no content, write '[Not documented for this pattern]'.
-- Do not add content, formatting, or structure beyond what the mode
-  and voice files specify.
+- Do not add content, formatting, or structure beyond what the
+  template and voice specify.
 
 IMPORTANT: End every response with the routing envelope. Do not skip it.
 
 ## Worked Example
 
-Input: /dojo explain wave computation
+Input: `/dojo explain wave computation`
 
-Step 1 (Route):
-  "explain wave computation" is not a reserved keyword. Continue.
-  No prefix override (no colon). Check trigger words.
-  "explain" matches Sensei trigger. Mode = Sensei.
-  "wave computation" matches alias "wave" -> wave-computation.
-  Pattern = wave-computation. Route reason: trigger-word: explain
-
-Step 2 (Read):
-  1. Read references/mode-sensei.md. Voice ID = miyagi.
-  2. Read .claude/references/patterns/pattern-wave-computation.md.
-  3. Read references/voice-miyagi.md.
-
-Step 3 (Synthesize):
-  Line 1: [Sensei | Wave Computation]
-  Body: Follow Sensei template and constraints in Miyagi voice using
-        wave-computation slots as source material
-  Last: dojo-envelope block with route metadata
+Route: "explain" -> Sensei mode. "wave" alias -> wave-computation.
+Read: mode-sensei.md (Voice=miyagi), pattern-wave-computation.md, voice-miyagi.md.
+Synthesize: [Sensei | Wave Computation] + Miyagi voice + dojo-envelope.
 
 ## Envelope Format
 
@@ -225,19 +221,27 @@ Every response MUST end with a routing envelope in a fenced code block
 using the `dojo-envelope` info string (not `yaml`):
 
 ```dojo-envelope
+envelope_version: 2
+query_type: single
 mode_selected: sensei
+patterns_selected:
+  - wave-computation
 pattern_selected: wave-computation
 route_reason: "trigger-word: explain"
 warnings: []
 ```
 
+`patterns_selected`: authoritative list. `pattern_selected`: shim (= first item, remove after one cycle).
+`query_type`: `single` | `compare` | `follow-up` | `disambiguation`
+`context_source`: include when resolved from context (e.g. `"advisor-envelope from prior turn"`).
+
 `route_reason` values:
 - `prefix-override: sensei:` (or `reference:`, `explain:`, `lookup:`)
-- `exact-slug`
-- `alias: wave`
-- `trigger-word: explain`
-- `conversation-context`
-- `default`
+- `exact-slug`, `alias: wave`, `trigger-word: explain`
+- `compare-trigger: vs`, `context-resolution:`, `structured-follow-up:`
+- `conversation-context`, `default`
+
+Envelope extraction regex: `/```(?:dojo|advisor)-envelope\n([\s\S]*?)```/`
 
 No `confidence` field. Confidence is derivable from route_reason:
 prefix-override and exact-slug are high, trigger-word and alias are

--- a/.claude/skills/agentic-dojo/references/context-resolution.md
+++ b/.claude/skills/agentic-dojo/references/context-resolution.md
@@ -1,0 +1,57 @@
+# Context Resolution
+
+**Purpose:** Resolves pattern context from prior conversation when `query_type = follow-up` or `structured follow-up`. 1-message lookback only.
+
+---
+
+## Resolution Algorithm
+
+```
+When query_type = follow-up:
+
+1. Check most recent assistant message for:
+   a. dojo-envelope block  -> extract patterns_selected[0]
+   b. advisor-envelope block -> extract ranked_patterns[0].slug
+
+2. Envelope found and pattern resolved:
+   Re-classify with resolved pattern; continue normal routing cascade.
+   MUST NOT produce another follow-up (recursion guard -- see Precedence table).
+
+3. No envelope found, parse fails, or required fields missing:
+   Hard error: "No pattern context found in recent conversation.
+   Please specify a pattern name, or try: /dojo help to see available patterns."
+```
+
+---
+
+## Ordinal Resolution
+
+When an `advisor-envelope` ranked list is present and the user says `first/second/third`, resolve to `ranked_patterns[N-1]`. If no ordinal, default to `ranked_patterns[0]`.
+
+---
+
+## `--context-pattern=<slug>` (Structured Follow-up)
+
+Skip envelope resolution entirely. Extract slug directly from flag. Validate slug against pattern catalog. Flag is repeatable (supports compare: `--context-pattern=task-dag --context-pattern=wave-computation`).
+
+---
+
+## Cross-Skill Bridge
+
+Parses `advisor-envelope` from the prior turn to extract `ranked_patterns[0].slug`. Does NOT invoke the advisor skill -- read the envelope only.
+
+---
+
+## Precedence Contract
+
+| Case | Behavior |
+|------|----------|
+| `--context-pattern=<slug>` provided and slug is invalid | Hard error: "Unknown context pattern `<slug>`" (no fallback) |
+| Pronoun follow-up and envelope parse fails/missing | Hard error: "No pattern context found..." (no fallback) |
+| Pronoun follow-up resolves to advisor ranked list + ordinal intent | Resolve ordinal if present, else default to first ranked pattern |
+| Re-classification after resolution yields follow-up again | Stop and emit "No pattern context found..." (recursion guard) |
+| Explicit patterns in current query conflict with resolved context | Explicit current-query patterns win |
+
+---
+
+> **Warning:** Context resolution requires main-thread conversation access. If the dojo skill is ever changed to `context: fork`, follow-up resolution will break entirely.

--- a/.claude/skills/agentic-dojo/references/mode-compare.md
+++ b/.claude/skills/agentic-dojo/references/mode-compare.md
@@ -1,0 +1,77 @@
+# Compare Mode
+
+**Character:** JARVIS (Iron Man / Marvel)
+**Purpose:** Side-by-side pattern comparison for exactly 2 patterns
+
+---
+
+## Voice ID
+
+jarvis
+
+## Synthesis Template
+
+Generate these sections in order:
+
+1. Breadcrumb: `[Compare | Pattern A Display Name vs Pattern B Display Name]`
+
+2. "At a Glance" -- table with one row per pattern:
+
+   | | Pattern A | Pattern B |
+   |---|---|---|
+   | Summary | one_liner | one_liner |
+   | Best for | When To Use (condensed) | When To Use (condensed) |
+
+3. "How They Differ" -- Core Mechanism slot for each pattern, presented
+   sequentially (not interleaved). Present Pattern A's mechanism, then
+   Pattern B's. Close with one sentence identifying the structural
+   difference between the two.
+
+4. "When To Choose Which" -- Synthesize from When To Use + Tradeoffs slots.
+   Present as:
+   - "Choose [A] when..." (2-3 conditions)
+   - "Choose [B] when..." (2-3 conditions)
+   - "Use both when..." (include only if related_patterns slot confirms a
+     complementary relationship between the two patterns)
+
+5. "Key Rules" -- Combined key rules from both patterns as a single list.
+   Annotate each rule with the pattern it applies to in parentheses.
+
+6. "Watch Out" -- Failure Modes from both patterns. Frame comparatively:
+   identify which failure modes are unique to each pattern, and which
+   are shared.
+
+7. "See Also" -- Related Patterns from both patterns, deduplicated.
+
+## Constraints
+
+- Maximum 2 patterns per compare. If the user provides 3 or more patterns,
+  route to disambiguation -- do not attempt a multi-way comparison.
+
+- Same pattern twice is an error. Respond with: "Cannot compare a pattern
+  with itself. Try: `/dojo explain <pattern>`"
+
+- Compare mode ignores mode prefix/trigger overrides. If the query triggers
+  compare, mode selection is locked to compare regardless of any explicit
+  mode prefix supplied.
+
+- JARVIS voice rules apply to all content within the comparison -- section
+  headings, table values, prose, and annotations.
+
+- If a slot has no content for a given pattern, write "[Not documented]"
+  inline -- do not skip the cell or list item.
+
+- The breadcrumb line is the only text before the first section heading.
+  No narrative introduction.
+
+- Do not add sections beyond what the template specifies. Seven sections
+  is the complete structure.
+
+- Do not generate content not grounded in the pattern file slots. If slot
+  content is thin, write less -- do not invent.
+
+- Word target: approximately 600 words (excluding the dojo-envelope block).
+  Prefer precision over coverage.
+
+- The dojo-envelope block is the final element of every response.
+  Do not omit it. Do not add content after it.

--- a/.claude/skills/agentic-dojo/references/query-classifier.md
+++ b/.claude/skills/agentic-dojo/references/query-classifier.md
@@ -1,0 +1,54 @@
+# Query Classifier
+
+**Purpose:** Deterministic query-type classifier. Runs in Step 1 after reserved-keyword
+check, before mode/pattern detection. Single query type falls straight through to the
+existing cascade -- nothing else changes.
+
+---
+
+## Two-Pass Resolution
+
+```
+Step 1a: Resolve all pattern slugs/aliases from $ARGUMENTS
+         (alias table only -- NOT keyword table)
+         Result: resolved_patterns[] with count
+
+Step 1b: Classify query type using resolved count + signals (see table below)
+
+Step 1c: single query type -> continue to existing mode/keyword cascade (unchanged)
+```
+
+---
+
+## Classification Rules
+
+| Signal | Query type | Condition |
+|--------|-----------|-----------|
+| `compare` prefix or trigger | compare | `$ARGUMENTS` starts with `compare:` OR contains "compare", "vs", "versus", "difference between", "differ from", "in common", "overlap", "similarities" |
+| 2 explicit + compare signal | compare | Two patterns resolved AND compare trigger present |
+| 2 explicit, no compare signal | compare | Exactly 2 patterns resolved (default: naming 2 = want comparison) |
+| `--context-pattern=<slug>` flag | structured follow-up | Extract slug(s) from flag directly; skip pronoun resolution (flag is repeatable) |
+| Pronoun/reference, no pattern name | follow-up | `$ARGUMENTS` contains "that one", "those", "it", or ordinal refs ("first"/"second"/"third") AND no explicit slug/alias resolved |
+| 3+ explicit slugs/aliases | disambiguation | Emit: "You named 3+ patterns. Compare supports 2 at a time. Which pair would you like to compare?" |
+| Everything else | single | Fallthrough to existing cascade |
+
+---
+
+## Classifier-to-Mode Mapping
+
+| Query type | Mode | Patterns read | Delivery |
+|------------|------|--------------|----------|
+| single | Existing cascade (Sensei/Reference) | 1 | Existing templates |
+| compare | Compare (new) | 2 | mode-compare.md template |
+| follow-up | Re-classify after context resolution | 1-2 | Depends on resolved query type |
+| structured follow-up | Same as single/compare (from flag) | 1-2 | Depends on flag value |
+| disambiguation | N/A | 0 | Error message -- ask user to narrow |
+
+---
+
+## Recursion Guard
+
+Re-classification after context resolution (follow-up path) MUST NOT produce
+another `follow-up`. If it does, stop immediately and emit:
+
+> "Could not resolve context reference. Please name the pattern explicitly."

--- a/.claude/skills/pattern-advisor/SKILL.md
+++ b/.claude/skills/pattern-advisor/SKILL.md
@@ -92,6 +92,11 @@ Extract signals from $ARGUMENTS. For each signal present, note it:
 | cross-session | resume session, interrupted, overnight, long pause, session ended |
 | ui-facing | UI, component, visual, screenshot, browser, layout, page, style |
 
+After keyword extraction, also detect structural signals:
+- Sequential/pipeline language ("first... then... finally") -> dependencies, multiple-tasks
+- Role differentiation ("one builds, another checks") -> verification-needed
+- Error narratives, iteration loops, scale/batch language -> map to closest characteristic
+
 ### Pattern Scoring
 
 Score each of the 19 patterns against the extracted characteristics.
@@ -155,6 +160,7 @@ Every response MUST end with a routing envelope in a fenced code block
 using the `advisor-envelope` info string (not `yaml`):
 
 ```advisor-envelope
+envelope_version: 2
 ranked_patterns:
   - slug: <top-pattern-slug>
     score: high
@@ -169,3 +175,5 @@ next_commands:
   - "/dojo explain <top-pattern-slug>"
   - "/dojo lookup <top-pattern-slug>"
 ```
+
+Envelope extraction regex: `/```(?:dojo|advisor)-envelope\n([\s\S]*?)```/`

--- a/.claude/skills/pattern-advisor/references/mode-advisor.md
+++ b/.claude/skills/pattern-advisor/references/mode-advisor.md
@@ -42,6 +42,7 @@ Generate these sections in order:
    ```
    /dojo explain <top-pattern-slug>    -- Sensei teaches the concept
    /dojo lookup <top-pattern-slug>     -- Quick structured reference
+   /dojo compare <slug-a> <slug-b>     -- Side-by-side comparison
    ```
 
    Follow with: "Should any of the other recommended patterns warrant

--- a/specs/reviews/smarter-routing-review-pass-1.md
+++ b/specs/reviews/smarter-routing-review-pass-1.md
@@ -1,0 +1,38 @@
+1. **Verdict**: **REQUEST CHANGES**
+
+2. **Strengths**
+- Extracting compare synthesis into a dedicated mode file keeps delivery concerns out of routing and aligns with existing HOP boundaries.
+- Moving from 5-message to 1-message context lookback is a strong simplification for v1 and reduces hidden state risk.
+- Standardizing on `patterns_selected` (list) is a good long-term normalization move.
+- Phase B semantic-signal addition is appropriately small and additive.
+
+3. **Critical issues** (must fix)
+- **Stop hook/schema mismatch will break validation immediately.**  
+  The dojo Stop hook currently expects `pattern_selected`; your plan replaces it with `patterns_selected` and adds `envelope_version`/`query_type`. Update hook contract in [agentic-dojo/SKILL.md](/Users/nathanvale/code/orchestrator-prototype/agentic-dojo/SKILL.md#L22) before rollout.
+- **Routing precedence is ambiguous for failed context resolution.**  
+  You currently have two conflicting outcomes: “emit error” vs “fall through to single.” Define strict precedence: `--context-pattern` invalid slug => hard error, pronoun follow-up unresolved => disambiguation prompt, never silent fallthrough.
+- **Cross-skill envelope coupling is unmanaged.**  
+  Dojo parsing advisor envelopes creates implicit API coupling. Add a minimal contract: required keys + version gate (`advisor envelope_version >= 2`) + graceful downgrade path, or this will silently rot.
+- **Agent discoverability gap for `--context-pattern`.**  
+  Without updating `argument-hint` and command examples, agent callers won’t know the flag exists. Update frontmatter/docs in [agentic-dojo/SKILL.md](/Users/nathanvale/code/orchestrator-prototype/agentic-dojo/SKILL.md#L1).
+
+4. **Important observations** (should fix)
+- **Category confusion is real but acceptable if documented.**  
+  Putting classifier logic in `references/query-classifier.md` mixes procedural policy with declarative references. That’s okay if you formally define a new “routing policy reference” type and keep mode files purely templating.
+- **Line-budget estimate is inaccurate.**  
+  Baseline is reported as 243 lines, not 207. Your +13 assumption is likely wrong; with frontmatter/help text updates you risk breaching the 250 ceiling. Re-estimate using actual file length in [agentic-dojo/SKILL.md](/Users/nathanvale/code/orchestrator-prototype/agentic-dojo/SKILL.md).
+- **Compare mode ignoring prefix overrides is a UX footgun.**  
+  `/dojo sensei: compare wave dag` likely implies “compare in Sensei voice.” Current rule (“compare always JARVIS”) violates least surprise. Either respect explicit prefix or emit an explicit warning.
+- **Phase dependency is slightly understated.**  
+  Phase A is coupled as stated, but schema/version changes also affect hooks and any parser logic; treat “hook update + parser update” as required within Phase A, not follow-up cleanup.
+
+5. **Nice-to-haves**
+- Add a tiny compatibility window: emit both `pattern_selected` (first item) and `patterns_selected` for one release cycle.
+- Add explicit `route_reason` taxonomy in one table to keep future edits deterministic.
+- Add one “golden envelope” fixture per query type for regression checks.
+
+6. **Questions for the author**
+- What is the authoritative precedence order when classification and context resolution disagree?
+- Will compare mode ever support non-JARVIS voices, or is this a permanent product decision?
+- What is the deprecation plan/timeline for `pattern_selected`?
+- Can we define an internal envelope contract doc so dojo/advisor evolve independently, Nathan?

--- a/specs/reviews/smarter-routing-review-pass-2.md
+++ b/specs/reviews/smarter-routing-review-pass-2.md
@@ -1,0 +1,34 @@
+**Verdict**  
+REQUEST CHANGES
+
+**Strengths**
+- You did trim scope compared to the original idea (`discover`/`multi` cut, 1-message lookback), which is the right direction.
+- Keeping compare output logic separate from core routing is cleaner than mixing synthesis into dispatch rules.
+- Calling out unknown-frequency gaps explicitly is honest and makes it easier to set evidence gates.
+
+**Critical Issues (must fix)**
+- No demand signal for the main additions. Every gap is “unknown frequency,” but the plan still ships classifier + compare + context bridge + schema evolution. That is platform-building without usage proof.
+- Compare mode is likely over-built for v1. “Two patterns in one query” can be handled with the existing multiple-pattern path plus a minimal “if exactly 2, render side-by-side” branch; a full new query-type system is not required.
+- Cross-skill context bridge is speculative. The described `/advisor` -> “explain that one” -> `/dojo` flow is plausible, but not evidenced. Current explicit invocation (`/dojo explain <pattern>`) already works and is clearer.
+- `--context-pattern` appears unnecessary for agent parity right now. Agents can already construct explicit commands from advisor output; adding a new flag creates another API surface to support.
+- Schema-change justification is not evidence-backed. “No external consumers” is an assertion that must be proven with a repo-wide reference audit before changing envelope fields.
+- “Phase B” for 3 lines of semantic signals is process overhead. This should be folded into one delivery unless there is a real rollout dependency.
+
+**Important Observations (should fix)**
+- The 250-line ceiling is driving architecture. If that ceiling is not empirically tied to model/tool performance, extracting routing into multiple reference files is complexity for a non-problem.
+- Research volume (many sources/agents) doesn’t map to validated user behavior. It reads like justification depth, not decision quality.
+- The deferred v2 list still shapes v1 design (query typing, versioning, abstraction seams). That is deferred-debt inversion: paying now for features that may never ship.
+- “Smarter routing” should target top 1-2 failures only. Right now it’s bundling routing, context memory, cross-skill bridging, schema policy, and agent interface design.
+
+**Nice-to-Haves**
+- Add a hard success metric before implementation (for example: “reduce clarification/error responses by X% in N real prompts”).
+- Add a kill switch (single toggle to disable compare/context behaviors if they confuse users).
+- Run a 1-week prompt log sample first, then implement only behaviors observed at least a small threshold (even 3-5 real occurrences is better than zero), Nathan.
+
+**Questions for the Author**
+1. What are 3 concrete, observed prompts from real usage that fail today and would be fixed by compare mode?  
+2. Why isn’t a minimal dual-pattern branch in existing routing sufficient for v1?  
+3. What real agent workflow fails without `--context-pattern`?  
+4. What repo-wide evidence supports “no consumers” for current envelope fields?  
+5. What measurable outcome defines success for this work after release?  
+6. If we had to cut 50% scope today, which exact pieces remain and why?

--- a/specs/reviews/smarter-routing-review-pass-3.md
+++ b/specs/reviews/smarter-routing-review-pass-3.md
@@ -1,0 +1,53 @@
+1. **Verdict**: **REQUEST CHANGES**
+
+2. **Strengths**
+- The plan clearly separates routing concerns from delivery templates, which keeps HOP boundaries clean and maintainable.
+- Two-pass classification (`resolve patterns` then `classify query type`) is explicit and easier to reason about than mixed heuristic routing.
+- The compare template is concrete and deterministic, which is good for consistency and testability.
+- The added manual test matrix extends into multi-turn behavior instead of only single-turn happy paths.
+
+3. **Critical issues (must fix)**
+- **Structured follow-up contract is internally inconsistent (`--context-pattern` vs `--context-patterns`)**.  
+  The classifier rule only defines singular flag handling, but examples/tests rely on plural for compare. This will confuse both humans and agents and cause routing drift.  
+  References: [plan.md#L182](/Users/nathanvale/code/orchestrator-prototype/docs/plans/2026-02-22-feat-smarter-routing-dojo-advisor-plan.md#L182), [plan.md#L312](/Users/nathanvale/code/orchestrator-prototype/docs/plans/2026-02-22-feat-smarter-routing-dojo-advisor-plan.md#L312), [plan.md#L655](/Users/nathanvale/code/orchestrator-prototype/docs/plans/2026-02-22-feat-smarter-routing-dojo-advisor-plan.md#L655)
+- **Compare trigger vocabulary is too narrow for natural phrasing.**  
+  Current trigger set misses common “similarity” intent (“in common”, “overlap”, “similarities”). Those queries will likely fall through to single/disambiguation unexpectedly.  
+  Reference: [plan.md#L179](/Users/nathanvale/code/orchestrator-prototype/docs/plans/2026-02-22-feat-smarter-routing-dojo-advisor-plan.md#L179)
+- **Follow-up resolution hardcodes first-ranked pattern and ignores explicit ordinal intent.**  
+  If advisor returns top 3 and user says “the second one,” this design returns `ranked_patterns[0]`, which is a deterministic wrong answer, not an edge case.  
+  References: [plan.md#L286](/Users/nathanvale/code/orchestrator-prototype/docs/plans/2026-02-22-feat-smarter-routing-dojo-advisor-plan.md#L286), [plan.md#L295](/Users/nathanvale/code/orchestrator-prototype/docs/plans/2026-02-22-feat-smarter-routing-dojo-advisor-plan.md#L295)
+- **`query_type` semantics are overloaded and ambiguous for consumers.**  
+  `follow-up` is treated as both an input classification and final envelope output type, while delivery mode is resolved after re-classification. This muddies observability and makes downstream tooling harder to reason about.  
+  References: [plan.md#L204](/Users/nathanvale/code/orchestrator-prototype/docs/plans/2026-02-22-feat-smarter-routing-dojo-advisor-plan.md#L204), [plan.md#L333](/Users/nathanvale/code/orchestrator-prototype/docs/plans/2026-02-22-feat-smarter-routing-dojo-advisor-plan.md#L333)
+
+4. **Important observations (should fix)**
+- **Discoverability is still incomplete across entry points.** Compare is added in zero-state, but argument hint and examples are still single/lookup-biased in the base spec; users and agents learn from examples first.  
+  Reference: [specs/agentic-dojo-skill.md#L146](/Users/nathanvale/code/orchestrator-prototype/specs/agentic-dojo-skill.md#L146)
+- **Disambiguation copy is mode-biased (“compare or explain”) and excludes lookup/reference intent.**  
+  This nudges users into a mode they didn’t request.  
+  References: [plan.md#L184](/Users/nathanvale/code/orchestrator-prototype/docs/plans/2026-02-22-feat-smarter-routing-dojo-advisor-plan.md#L184), [plan.md#L461](/Users/nathanvale/code/orchestrator-prototype/docs/plans/2026-02-22-feat-smarter-routing-dojo-advisor-plan.md#L461)
+- **CLI-style flag UX is unnatural for a conversational slash skill.**  
+  Keep it for agents if needed, but make it explicitly “agent-only” and preserve a human-first invocation path.
+- **“At a Glance” using only `one_liner` may underserve comparisons.**  
+  For side-by-side choice, short `quick_summary` is likely more useful than a one-sentence tagline.  
+  Reference: [plan.md#L223](/Users/nathanvale/code/orchestrator-prototype/docs/plans/2026-02-22-feat-smarter-routing-dojo-advisor-plan.md#L223)
+- **Envelope regex is only documented in planning text, not clearly in runtime-facing docs.**  
+  Parser contracts should live where implementers look first (skill docs or dedicated contract file), not only in plan prose.  
+  Reference: [plan.md#L410](/Users/nathanvale/code/orchestrator-prototype/docs/plans/2026-02-22-feat-smarter-routing-dojo-advisor-plan.md#L410)
+
+5. **Nice-to-haves**
+- Add minimal ordinal resolution (`first|second|third`) for advisor follow-ups.
+- Normalize query type naming to one style (`snake_case` or `kebab-case`) and keep it internal-only.
+- Add compare examples to zero-state + argument hint + advisor next-steps copy, not just mode lists.
+- Add targeted tests for similarity-language compare intents (“in common”, “overlap”, “similarities”).
+
+6. **Questions for the author**
+1. Is `--context-patterns` officially part of the contract, or should compare reuse repeated `--context-pattern` args?
+2. Should ordinal follow-ups (“first/second/third”) be in v1.1 scope since advisor always returns ranked lists?
+3. Do you want `query_type` to represent user utterance shape, resolved route, or both (separate fields)?
+4. Is `--context-pattern` intended for humans, agents, or both? If agents-only, where is that stated?
+5. Do we want disambiguation prompts to be mode-neutral (`compare / explain / lookup`) by default?
+6. Where is the canonical envelope parser contract for other maintainers besides this plan doc?
+
+7. **Synthesis**
+The combined reviews have de-risked architecture and scope significantly, but DX risk is still high in interaction semantics: discoverability is uneven, structured-argument contract is inconsistent, and follow-up resolution currently favors deterministic-but-wrong behavior for natural ranked-list references. Nathan, I’d move to implementation only after clarifying the structured flag contract, expanding compare intent vocabulary, and defining unambiguous follow-up/query-type semantics for both users and parser consumers.

--- a/specs/smarter-routing-execution-plan.md
+++ b/specs/smarter-routing-execution-plan.md
@@ -1,0 +1,416 @@
+# Plan: Smarter Routing for Agentic Dojo & Pattern Advisor
+
+## Task Description
+
+Implement the smarter routing plan from `docs/plans/2026-02-22-feat-smarter-routing-dojo-advisor-plan.md`. This adds a query-type classifier, compare mode, conversation context resolution, and semantic signal extraction to the dojo and advisor skills. All changes are prompt-level (markdown files) -- no TypeScript code.
+
+## Objective
+
+When complete:
+- `/dojo wave dag` routes to compare mode (not error)
+- `/dojo explain that one` after an advisor response resolves from context
+- `/dojo explain --context-pattern=task-dag` works for agents
+- `/advisor "CI pipeline: lint, test, build, deploy"` detects structural signals
+- Dojo envelopes emit `envelope_version: 2`, `query_type`, and `patterns_selected` (list)
+- Advisor envelope emits `envelope_version: 2`
+- Dojo SKILL.md stays under 250 lines (actual baseline: 243 lines)
+
+## Problem Statement
+
+The v1 routing is a lexical cascade that breaks on compound queries (2 patterns), follow-ups ("explain that one"), and cross-skill handoffs. The plan adds a deterministic classifier layer above the existing cascade without changing content delivery.
+
+## Solution Approach
+
+All changes are markdown edits to skill files and new reference files. No TypeScript or infrastructure. Validation includes structural checks plus manual smoke behavior checks from the hardened plan. The work decomposes into 5 builder tasks (sequential with validation after each) plus one final integration validation.
+
+**Key constraint:** The dojo SKILL.md is already at 243 lines (the plan incorrectly says 207). The 250-line ceiling gives only 7 lines of headroom. The plan estimates +13 net lines. To stay under 250, more content must be extracted to reference files than the plan specifies, OR the plan's net delta must be reduced to +7 or fewer. Builders must count lines and report actuals.
+
+## Relevant Files
+
+**Files to modify:**
+- `.claude/skills/agentic-dojo/SKILL.md` (243 lines) -- routing, envelope format, error contract, zero-state, stop hook
+- `.claude/skills/pattern-advisor/SKILL.md` (171 lines) -- characteristic extraction, envelope format
+- `.claude/skills/pattern-advisor/references/mode-advisor.md` (71 lines) -- Next Steps compare handoff example
+
+**Files to create:**
+- `.claude/skills/agentic-dojo/references/query-classifier.md` (~30 lines) -- classification table and rules
+- `.claude/skills/agentic-dojo/references/context-resolution.md` (~20 lines) -- follow-up resolution algorithm
+- `.claude/skills/agentic-dojo/references/mode-compare.md` (~80 lines) -- compare synthesis template
+
+**Files to read for context (do NOT modify):**
+- `.claude/skills/agentic-dojo/references/mode-sensei.md` (84 lines) -- template pattern to follow
+- `.claude/skills/agentic-dojo/references/mode-reference.md` (76 lines) -- template pattern to follow
+- `.claude/skills/agentic-dojo/references/voice-jarvis.md` (78 lines) -- compare voice
+- `.claude/skills/agentic-dojo/references/voice-miyagi.md` (78 lines) -- sensei voice
+- `.claude/skills/agentic-dojo/references/VOICE-CONTRACT.md` -- voice file contract
+- `.claude/skills/pattern-advisor/references/mode-advisor.md` (71 lines) -- advisor template pattern
+- `.claude/references/patterns/pattern-wave-computation.md` -- example pattern for testing templates
+- `docs/plans/2026-02-22-feat-smarter-routing-dojo-advisor-plan.md` -- source of truth for all specifications
+
+## Contract Packet (mandatory pre-read for every agent)
+
+Before any builder or validator starts work, read these plan sections in full:
+- `Improvement 1: Query-type classifier` (classifier rules and trigger vocabulary)
+- `Improvement 2: Comparison mode` (mode structure + constraints)
+- `Improvement 3: Conversation context resolution` (precedence and ordinal handling)
+- `System-Wide Impact > Envelope schema evolution` (v2 fields + compatibility shim)
+- `Acceptance Criteria` and `Quality Gates` (final authority for PASS/FAIL)
+
+Additionally required by role:
+- Builders editing mode files: read `.claude/skills/agentic-dojo/references/VOICE-CONTRACT.md`
+- Builders/validators touching stop hooks: read current `.claude/skills/agentic-dojo/SKILL.md` stop hook block before any edit/check
+- Validators: read this execution plan's `Acceptance Criteria` immediately before validation to avoid stale assumptions
+
+If contract sources conflict, precedence is:
+1. `docs/plans/2026-02-22-feat-smarter-routing-dojo-advisor-plan.md`
+2. `specs/smarter-routing-execution-plan.md`
+3. Existing file conventions (`mode-sensei.md`, `mode-reference.md`, `mode-advisor.md`)
+
+### New Files
+
+- `.claude/skills/agentic-dojo/references/query-classifier.md`
+- `.claude/skills/agentic-dojo/references/context-resolution.md`
+- `.claude/skills/agentic-dojo/references/mode-compare.md`
+
+## Implementation Phases
+
+### Phase 1: Foundation (Tasks 1-2)
+Create the two extracted reference files: query-classifier.md and context-resolution.md. These are self-contained and define the routing logic that SKILL.md will reference.
+
+### Phase 2: Core Implementation (Tasks 3-4)
+Create mode-compare.md, then edit dojo SKILL.md to wire everything together: add reference reads, update zero-state, update envelope format, update error contract, update stop hook. This is the most sensitive task because of the 250-line ceiling.
+
+### Phase 3: Advisor & Integration (Tasks 5-6)
+Add semantic signals to advisor SKILL.md, then run full integration validation across all files.
+
+## Team Orchestration
+
+- You operate as the team lead and orchestrate the team to execute the plan.
+- IMPORTANT: You NEVER operate directly on the codebase. Use Task and Task* tools only.
+- Take note of the session id (agentId) of each team member for resume operations.
+
+### Model Selection Guide
+
+| Role | Model | Rationale |
+|------|-------|-----------|
+| All builders | sonnet | Executes well-specified tasks reliably |
+| All validators | haiku | Mechanical checks: read files, run commands, report PASS/FAIL |
+
+### Team Members
+
+- Builder
+  - Name: builder-classifier
+  - Role: Create query-classifier.md and context-resolution.md reference files
+  - Agent Type: agentic-orchestration:builder
+  - Model: sonnet
+  - Resume: true
+
+- Builder
+  - Name: builder-compare-mode
+  - Role: Create mode-compare.md reference file
+  - Agent Type: agentic-orchestration:builder
+  - Model: sonnet
+  - Resume: true
+
+- Builder
+  - Name: builder-dojo-skill
+  - Role: Edit dojo SKILL.md (routing, envelope, errors, stop hook, zero-state)
+  - Agent Type: agentic-orchestration:builder
+  - Model: sonnet
+  - Resume: true
+
+- Builder
+  - Name: builder-advisor-skill
+  - Role: Edit advisor SKILL.md (semantic signals, envelope version)
+  - Agent Type: agentic-orchestration:builder
+  - Model: sonnet
+  - Resume: true
+
+- Validator
+  - Name: validator-files
+  - Role: Validate each builder's output against plan spec
+  - Agent Type: agentic-orchestration:validator
+  - Model: haiku
+  - Resume: true
+
+- Validator
+  - Name: validator-integration
+  - Role: Final cross-file integration validation
+  - Agent Type: agentic-orchestration:validator
+  - Model: haiku
+  - Resume: true
+
+## Step by Step Tasks
+
+- Execute every step in order, top to bottom.
+- Before starting, run TaskCreate for each task so all team members can see the full plan.
+- Every validator task must produce a gate artifact entry before the next task can start.
+- Gate artifact file: `specs/reviews/smarter-routing-execution-gates.md`
+- Gate entry format (required): `Task ID`, `Status: PASS|FAIL`, `Checklist`, `Blocking Issues`, `Line Counts` (when relevant), `Timestamp`.
+
+### 1. Create query-classifier.md
+- **Task ID**: create-query-classifier
+- **Depends On**: none
+- **Assigned To**: builder-classifier
+- **Agent Type**: agentic-orchestration:builder
+- **Model**: sonnet
+- **Parallel**: false
+- Read `docs/plans/2026-02-22-feat-smarter-routing-dojo-advisor-plan.md` sections: "Improvement 1: Query-type classifier" (lines 113-167)
+- Read existing mode files (`mode-sensei.md`, `mode-reference.md`) to understand the reference file style
+- Create `.claude/skills/agentic-dojo/references/query-classifier.md` (~30 lines) containing:
+  - Two-pass resolution instructions (Step 1a: aliases, Step 1b: classify)
+  - Classification rules table (7 rows: compare prefix/trigger, 2 explicit + compare, 2 explicit no compare, --context-pattern flag, pronoun/reference, 3+ explicit, everything else)
+  - Compare trigger words: "compare", "vs", "versus", "difference between", "differ from", "in common", "overlap", "similarities"
+  - Pronoun/reference triggers: "that one", "those", "it", ordinal refs ("first/second/third")
+  - Classifier-to-mode mapping table (single, compare, follow-up, structured follow-up, disambiguation)
+  - Recursion guard note: re-classification after context resolution MUST NOT produce another follow-up
+- Target: ~30 lines, clear and concise
+- File should NOT have frontmatter -- it's a routing policy reference, not a mode file
+
+### 2. Create context-resolution.md
+- **Task ID**: create-context-resolution
+- **Depends On**: none
+- **Assigned To**: builder-classifier
+- **Agent Type**: agentic-orchestration:builder
+- **Model**: sonnet
+- **Parallel**: false (sequential execution required by this plan)
+- Read `docs/plans/2026-02-22-feat-smarter-routing-dojo-advisor-plan.md` sections: "Improvement 3: Conversation context resolution" (lines 235-303)
+- Create `.claude/skills/agentic-dojo/references/context-resolution.md` (~20 lines) containing:
+  - 1-message lookback algorithm (check most recent assistant message for dojo-envelope or advisor-envelope)
+  - Ordinal resolution: if advisor ranked list present and user says "first/second/third", resolve to ranked_patterns[N-1]
+  - `--context-pattern=<slug>` handling: skip envelope resolution entirely, extract slug directly, validate slug exists
+  - Cross-skill bridge: parse advisor-envelope -> ranked_patterns[0].slug (or ordinal)
+  - Precedence contract table (5 rows from plan lines 284-290)
+  - Warning: requires main-thread conversation access (context: fork would break this)
+- Target: ~20 lines
+
+### 3. Validate reference files
+- **Task ID**: validate-reference-files
+- **Depends On**: create-query-classifier, create-context-resolution
+- **Assigned To**: validator-files
+- **Agent Type**: agentic-orchestration:validator
+- **Model**: haiku
+- **Parallel**: false
+- Read both new files and verify:
+  - `query-classifier.md` contains all 7 classification rules from the plan
+  - `query-classifier.md` includes expanded compare triggers ("in common", "overlap", "similarities")
+  - `query-classifier.md` includes ordinal refs in follow-up triggers
+  - `context-resolution.md` contains precedence contract (all 5 cases)
+  - `context-resolution.md` includes ordinal resolution for advisor ranked list
+  - `context-resolution.md` includes `--context-pattern` handling
+  - `context-resolution.md` includes context:fork warning
+  - Neither file has frontmatter (they're routing policy, not modes)
+  - Both files are concise (~30 and ~20 lines respectively)
+- Write gate artifact entry for `validate-reference-files` in `specs/reviews/smarter-routing-execution-gates.md`
+- If FAIL: do not proceed; reopen `create-query-classifier` and/or `create-context-resolution`
+
+### 4. Create mode-compare.md
+- **Task ID**: create-mode-compare
+- **Depends On**: validate-reference-files
+- **Assigned To**: builder-compare-mode
+- **Agent Type**: agentic-orchestration:builder
+- **Model**: sonnet
+- **Parallel**: false
+- Read `docs/plans/2026-02-22-feat-smarter-routing-dojo-advisor-plan.md` section: "Improvement 2: Comparison mode" (lines 169-233)
+- Read `mode-sensei.md` and `mode-reference.md` for structural template (header, Voice ID section, Synthesis Template, Constraints)
+- Read `VOICE-CONTRACT.md` for voice file conventions
+- Create `.claude/skills/agentic-dojo/references/mode-compare.md` (~80 lines) containing:
+  - Header: `# Compare Mode` with Character (JARVIS) and Purpose
+  - Voice ID: `jarvis`
+  - Synthesis Template with 7 sections: Breadcrumb, At a Glance table, How They Differ, When To Choose Which, Key Rules (combined), Watch Out (comparative), See Also (deduplicated)
+  - Constraints section: max 2 patterns, same-pattern error, ignores prefix overrides, JARVIS voice applies, word target ~600
+  - Follow the same structural pattern as mode-sensei.md (Voice ID section, Synthesis Template, Constraints)
+- Target: ~80 lines
+
+### 5. Validate mode-compare.md
+- **Task ID**: validate-mode-compare
+- **Depends On**: create-mode-compare
+- **Assigned To**: validator-files
+- **Agent Type**: agentic-orchestration:validator
+- **Model**: haiku
+- **Parallel**: false
+- Read `mode-compare.md` and verify:
+  - Has Voice ID section with value `jarvis`
+  - Has Synthesis Template with all 7 sections from the plan
+  - Has Constraints section covering: max 2 patterns, same-pattern error, prefix override behavior, voice applicability
+  - Structural consistency with `mode-sensei.md` and `mode-reference.md` (same section hierarchy)
+  - No frontmatter (mode files don't have frontmatter -- check existing mode files to confirm)
+  - Line count is ~80 (within 60-100 range)
+- Write gate artifact entry for `validate-mode-compare` in `specs/reviews/smarter-routing-execution-gates.md`
+- If FAIL: do not proceed; reopen `create-mode-compare`
+
+### 6. Edit dojo SKILL.md
+- **Task ID**: edit-dojo-skill
+- **Depends On**: validate-mode-compare
+- **Assigned To**: builder-dojo-skill
+- **Agent Type**: agentic-orchestration:builder
+- **Model**: sonnet
+- **Parallel**: false
+- Read `docs/plans/2026-02-22-feat-smarter-routing-dojo-advisor-plan.md` fully for all SKILL.md change specifications
+- Read current `.claude/skills/agentic-dojo/SKILL.md` (243 lines) completely before any edits
+- **CRITICAL: Final line count must be <= 250 lines. Current baseline is 243, not 207.**
+- Make these edits:
+
+  **Frontmatter (lines 1-30):**
+  - Update `argument-hint` to include compare example and --context-pattern example
+  - Update Stop hook: change `pattern_selected` check to accept both `pattern_selected` and `patterns_selected` (compatibility window)
+
+  **Zero-state (lines 52-70):**
+  - Add `compare <pattern> <pattern>` to Modes section
+  - Add compare example to Examples section
+
+  **Step 1: Route (after line 49, before Mode Detection):**
+  - Add instruction to read `references/query-classifier.md` after reserved-keyword check
+  - Add instruction to read `references/context-resolution.md` when query_type = follow-up
+
+  **Error Contract (lines 152-164):**
+  - Change "Multiple patterns detected" row: 2 explicit = compare route, 3+ explicit = disambiguation
+  - Add new row: "Compare with same pattern twice" = error
+  - Update disambiguation message to be mode-neutral: "Which pair for compare, which one for explain or lookup?"
+  - Add tip to "Unknown pattern" error: "Try /advisor for recommendations"
+
+  **"Does NOT Do" section (line 171):**
+  - Remove "Does not compare patterns side-by-side (v2 consideration)" -- it does now
+
+  **Step 2: Read (lines 173-184):**
+  - Add compare mode reading: when mode = compare, read mode-compare.md + pattern-A file + pattern-B file + voice-jarvis.md
+  - Make pattern reads plural-aware (read 1 or 2 pattern files depending on query type)
+
+  **Envelope Format (lines 221-243):**
+  - Add `envelope_version: 2` field
+  - Add `query_type` field (values: single, compare, follow-up, disambiguation)
+  - Change `pattern_selected` to `patterns_selected` (list)
+  - Add `pattern_selected` compatibility shim (= first item of patterns_selected)
+  - Add `context_source` field (when follow-up resolved)
+  - Add envelope extraction contract regex
+  - Update route_reason values list to include "compare-trigger:", "context-resolution:", "structured-follow-up:"
+
+  **After editing:** Count total lines with `wc -l`. If over 250, extract more content to reference files. Report final line count.
+
+### 7. Validate dojo SKILL.md
+- **Task ID**: validate-dojo-skill
+- **Depends On**: edit-dojo-skill
+- **Assigned To**: validator-files
+- **Agent Type**: agentic-orchestration:validator
+- **Model**: haiku
+- **Parallel**: false
+- Read the edited SKILL.md and verify:
+  - Line count <= 250 (run `wc -l`)
+  - Stop hook checks for both `pattern_selected` and `patterns_selected`
+  - Zero-state includes compare mode and example
+  - Argument-hint includes compare and --context-pattern examples
+  - Step 1 references query-classifier.md and context-resolution.md
+  - Error contract has: 2-explicit=compare, 3+=disambiguation, same-pattern=error, mode-neutral disambiguation text, /advisor tip
+  - "Does NOT Do" no longer mentions compare
+  - Step 2 handles compare mode (reads 2 pattern files + mode-compare + voice-jarvis)
+  - Envelope format includes all v2 fields (envelope_version, query_type, patterns_selected, pattern_selected shim, context_source)
+  - Envelope extraction regex is documented
+  - route_reason values include new types
+- Write gate artifact entry for `validate-dojo-skill` in `specs/reviews/smarter-routing-execution-gates.md`
+- Include explicit line count in gate entry (`wc -l .claude/skills/agentic-dojo/SKILL.md`)
+- If FAIL: do not proceed; reopen `edit-dojo-skill`
+
+### 8. Edit advisor SKILL.md
+- **Task ID**: edit-advisor-skill
+- **Depends On**: validate-dojo-skill
+- **Assigned To**: builder-advisor-skill
+- **Agent Type**: agentic-orchestration:builder
+- **Model**: sonnet
+- **Parallel**: false
+- Read `docs/plans/2026-02-22-feat-smarter-routing-dojo-advisor-plan.md` section: "Improvement 4: Semantic signal extraction" (lines 305-330)
+- Read current `.claude/skills/pattern-advisor/SKILL.md` (171 lines)
+- Make these edits:
+
+  **After Characteristic Extraction table (after line 94):**
+  - Add 3-line structural signal guidance:
+    ```
+    After keyword extraction, also detect structural signals:
+    - Sequential/pipeline language ("first... then... finally") -> dependencies, multiple-tasks
+    - Role differentiation ("one builds, another checks") -> verification-needed
+    - Error narratives, iteration loops, scale/batch language -> map to closest characteristic
+    ```
+
+  **Envelope Format (lines 152-171):**
+  - Add `envelope_version: 2` field to the example envelope
+  - Add envelope extraction contract regex (same as dojo)
+
+  **Next Steps in mode-advisor.md (separate file):**
+  - Read `mode-advisor.md` and add `/dojo compare <slug-a> <slug-b>` to the Next Steps command examples
+
+### 9. Validate advisor SKILL.md
+- **Task ID**: validate-advisor-skill
+- **Depends On**: edit-advisor-skill
+- **Assigned To**: validator-files
+- **Agent Type**: agentic-orchestration:validator
+- **Model**: haiku
+- **Parallel**: false
+- Read the edited advisor SKILL.md and verify:
+  - Structural signal guidance appears after characteristic extraction table (3 lines)
+  - Envelope includes `envelope_version: 2`
+  - Envelope extraction regex is documented
+  - Existing characteristic extraction table is unchanged
+  - Existing scoring guide is unchanged
+- Read `mode-advisor.md` and verify:
+  - Next Steps includes `/dojo compare` command example
+- Write gate artifact entry for `validate-advisor-skill` in `specs/reviews/smarter-routing-execution-gates.md`
+- Include explicit line counts for advisor files in gate entry
+- If FAIL: do not proceed; reopen `edit-advisor-skill`
+
+### 10. Final Integration Validation
+- **Task ID**: validate-integration
+- **Depends On**: validate-advisor-skill
+- **Assigned To**: validator-integration
+- **Agent Type**: agentic-orchestration:validator
+- **Model**: haiku
+- **Parallel**: false
+- Cross-file consistency checks:
+  - Dojo SKILL.md references `query-classifier.md` -- verify that file exists and contains the expected classification rules
+  - Dojo SKILL.md references `context-resolution.md` -- verify that file exists and contains the expected resolution algorithm
+  - Dojo SKILL.md references `mode-compare.md` -- verify that file exists with Voice ID = jarvis
+  - Compare mode references `voice-jarvis.md` -- verify voice file exists (it does, pre-existing)
+  - All dojo envelope examples use `envelope_version: 2`, `query_type`, and `patterns_selected` (list)
+  - Advisor envelope example uses `envelope_version: 2`
+  - Dojo stop hook validates both `pattern_selected` and `patterns_selected`
+  - No file exceeds its line budget (dojo SKILL.md <= 250, advisor SKILL.md <= 200)
+  - Grep all files for `pattern_selected` (singular, not in `patterns_selected`) to verify only the compatibility shim uses it
+  - Verify mode-compare.md follows the same structural pattern as mode-sensei.md (Voice ID, Synthesis Template, Constraints)
+  - Report final line counts for all 5 modified/created files
+- Confirm all prior gate entries exist and are PASS before issuing final PASS
+- Write final gate artifact entry for `validate-integration` in `specs/reviews/smarter-routing-execution-gates.md`
+
+## Acceptance Criteria
+
+- [ ] `query-classifier.md` exists with 7 classification rules, expanded compare triggers, ordinal follow-up triggers
+- [ ] `context-resolution.md` exists with precedence contract, ordinal resolution, --context-pattern handling, context:fork warning
+- [ ] `mode-compare.md` exists with JARVIS voice, 7-section template, constraints
+- [ ] Dojo SKILL.md <= 250 lines with all v2 changes (classifier refs, compare in Step 2, envelope v2, updated errors, updated stop hook)
+- [ ] Dojo stop hook accepts both `pattern_selected` and `patterns_selected`
+- [ ] Advisor SKILL.md has 3-line semantic signal guidance and envelope_version: 2
+- [ ] mode-advisor.md Next Steps includes `/dojo compare` example
+- [ ] Dojo envelope examples use v2 format with `patterns_selected` as list
+- [ ] Advisor envelope example uses `envelope_version: 2`
+- [ ] Zero-state shows compare mode with example
+- [ ] "Does NOT Do" no longer mentions compare as v2
+- [ ] Error contract distinguishes 2-explicit (compare) from 3+ (disambiguation) from keyword ambiguity
+- [ ] `specs/reviews/smarter-routing-execution-gates.md` contains PASS entries for tasks 3, 5, 7, 9, and 10
+
+## Validation Commands
+
+No TypeScript in scope -- all files are markdown. Validation is structural:
+- `wc -l` on all modified files to verify line budgets
+- `grep -r "pattern_selected" .claude/skills/` to verify singular form only in compatibility shim
+- Visual inspection of file structure and content against plan spec
+- Manual smoke behavior checks for key flows:
+  - `/dojo wave dag` routes to compare
+  - `/dojo compare wave wave` produces same-pattern error
+  - Follow-up resolution after advisor and dojo envelopes
+  - Invalid `--context-pattern` produces hard error
+  - Similarity-language compare trigger (for example: "in common")
+
+## Notes
+
+- **Line budget is the #1 risk.** The plan says baseline is 207 but actual is 243. With +13 net change that's 256 -- over the 250 ceiling. The builder for task 6 MUST track line count and may need to extract more content to reference files.
+- **This is all markdown.** No TypeScript or infrastructure changes. Validation is structural plus manual smoke behavior checks.
+- **The plan has been through 3 review passes** (Architect, Skeptic, DX Advocate). Review feedback has already been incorporated into the plan: compatibility shim for pattern_selected, expanded compare triggers, ordinal follow-up handling, precedence contract, stop-hook update requirement.
+- **mode-advisor.md edit** (adding compare to Next Steps) is a separate file from advisor SKILL.md but assigned to the same builder for task 8.
+- **Sequential execution is mandatory.** Each builder's output must be validated before the next builder starts, because later tasks depend on earlier files existing and being correct.


### PR DESCRIPTION
## Summary

- Add query-type classifier with 7 deterministic rules (compare, follow-up, disambiguation, structured follow-up, single)
- Add compare mode with JARVIS voice for side-by-side pattern comparison (exactly 2 patterns)
- Add conversation context resolution with 1-message lookback and `--context-pattern` flag for agents
- Upgrade envelope to v2: `patterns_selected` (list), `query_type`, `envelope_version`, extraction regex
- Add 3-line semantic signal guidance to advisor for structural pattern detection
- Dojo SKILL.md at 248/250 line budget

## Files Changed

**New (3):**
- `.claude/skills/agentic-dojo/references/query-classifier.md` (54 lines) - classification rules
- `.claude/skills/agentic-dojo/references/context-resolution.md` (57 lines) - follow-up resolution
- `.claude/skills/agentic-dojo/references/mode-compare.md` (77 lines) - compare synthesis template

**Modified (3):**
- `.claude/skills/agentic-dojo/SKILL.md` - routing, envelope v2, error contract, stop hook, zero-state
- `.claude/skills/pattern-advisor/SKILL.md` - semantic signals, envelope v2
- `.claude/skills/pattern-advisor/references/mode-advisor.md` - `/dojo compare` in Next Steps

## Test plan

- [ ] `/dojo wave dag` routes to compare mode (not error)
- [ ] `/dojo compare wave wave` produces same-pattern error
- [ ] `/dojo explain wave` then "explain that one" resolves from context
- [ ] `/dojo explain --context-pattern=task-dag` routes directly
- [ ] `/advisor "CI pipeline: lint, test, build, deploy"` detects structural signals
- [ ] Envelope includes `envelope_version: 2` and `patterns_selected` (list)
- [ ] Dojo stop hook accepts both `pattern_selected` and `patterns_selected`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Compare Mode for structured side-by-side pattern comparisons; new compare command for two-pattern comparisons
  * Query classification routing for clearer mode selection and follow-up handling

* **Enhancements**
  * Broader handling of single vs. multiple pattern inputs and explicit compare/list routing
  * Updated response synthesis rules (voice, template, slot handling) and stricter envelope fields/format

* **Documentation**
  * New guides for Compare Mode, context resolution, and query classification; expanded examples and improved error/guidance text
<!-- end of auto-generated comment: release notes by coderabbit.ai -->