### PR TITLE
Add 13 proposed patterns for future course modules

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -65,6 +65,7 @@ Pattern reference files in `.claude/references/patterns/` use a canonical 11-slo
 slug: <kebab-case-identifier>
 display_name: "<Human-readable name>"
 one_liner: "<One sentence description of what the pattern does>"
+intel_date: YYYY-MM-DD | null
 slots:
   pattern_id: "## Pattern ID"
   quick_summary: "## Quick Summary"
@@ -79,6 +80,15 @@ slots:
   source_anchors: "## Source Anchors"
 ---
 ```
+
+### Top-Level Metadata Fields
+
+| Field | Format | Purpose |
+|-------|--------|---------|
+| `slug` | kebab-case string | Unique pattern identifier |
+| `display_name` | quoted string | Human-readable name |
+| `one_liner` | quoted string | One sentence description |
+| `intel_date` | `YYYY-MM-DD` or `null` | Date the Source Anchors were last researched. Use `null` for patterns that predate community research tracking. |
 
 ### Slot Definitions
 
@@ -141,7 +151,7 @@ Source anchors use the format `<branch>:<file-path>:L<start>-L<end>`. The `sed -
 ## Adding a New Pattern
 
 1. Create `.claude/references/patterns/pattern-<slug>.md` with 11-slot frontmatter
-   (copy an existing pattern file as template -- verify all 11 slots are present)
+   (copy an existing pattern file as template -- verify all 11 slots and `intel_date` are present)
 2. Add keyword row to `.claude/skills/agentic-dojo/SKILL.md` Step 2 pattern table
 3. Add aliases to SKILL.md Step 2 alias table
 4. Add slug to SKILL.md zero-state pattern list

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -2,9 +2,9 @@
 
 This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
 
-## Orchestrator Prototype -- Learning Lobby
+## My Agent Dojo -- Learning Lobby
 
-This is the **lobby** branch of the HOP Orchestrator prototype -- a learning hub for agent orchestration patterns. Main holds the learning tools and pattern library. Each module branch (`orchestration/1-dispatch`, `orchestration/2-dag`, etc.) is a standalone lesson you checkout to see a working orchestrator at that complexity level.
+This is the **lobby** branch of My Agent Dojo -- a learning hub for agent orchestration patterns. Main holds the learning tools and pattern library. Each module branch (`orchestration/1-dispatch`, `orchestration/2-dag`, etc.) is a standalone lesson you checkout to see a working orchestrator at that complexity level.
 
 **Stack:** TypeScript, Bun, Biome, Claude Code agents/skills/commands
 

--- a/.claude/references/patterns/pattern-browser-validation.md
+++ b/.claude/references/patterns/pattern-browser-validation.md
@@ -2,6 +2,7 @@
 slug: browser-validation
 display_name: "Browser Validation"
 one_liner: "For UI-facing tasks, the validator uses the agent-browser CLI to take screenshots and assert visual/functional correctness after a builder completes."
+intel_date: null
 slots:
   pattern_id: "## Pattern ID"
   quick_summary: "## Quick Summary"

--- a/.claude/references/patterns/pattern-builder-validator.md
+++ b/.claude/references/patterns/pattern-builder-validator.md
@@ -2,6 +2,7 @@
 slug: builder-validator
 display_name: "Builder/Validator"
 one_liner: "Separate code execution from verification by assigning each role to a distinct agent with non-overlapping tool sets."
+intel_date: null
 slots:
   pattern_id: "## Pattern ID"
   quick_summary: "## Quick Summary"

--- a/.claude/references/patterns/pattern-difficulty-routing.md
+++ b/.claude/references/patterns/pattern-difficulty-routing.md
@@ -2,6 +2,7 @@
 slug: difficulty-routing
 display_name: "Difficulty Routing"
 one_liner: "Score each task against a difficulty rubric during decomposition and route hard tasks to a more capable execution engine, with graceful fallback to the standard builder."
+intel_date: null
 slots:
   pattern_id: "## Pattern ID"
   quick_summary: "## Quick Summary"

--- a/.claude/references/patterns/pattern-dispatch-loop.md
+++ b/.claude/references/patterns/pattern-dispatch-loop.md
@@ -2,6 +2,7 @@
 slug: dispatch-loop
 display_name: "Dispatch Loop"
 one_liner: "A central coordinator agent sequences task creation, Builder dispatch, and Validator dispatch without writing code itself."
+intel_date: null
 slots:
   pattern_id: "## Pattern ID"
   quick_summary: "## Quick Summary"

--- a/.claude/references/patterns/pattern-fast-path-gate.md
+++ b/.claude/references/patterns/pattern-fast-path-gate.md
@@ -2,6 +2,7 @@
 slug: fast-path-gate
 display_name: "Fast Path Gate"
 one_liner: "A hard complexity filter that routes simple prompts directly to a single Builder/Validator pair, bypassing the full DAG pipeline."
+intel_date: null
 slots:
   pattern_id: "## Pattern ID"
   quick_summary: "## Quick Summary"

--- a/.claude/references/patterns/pattern-higher-order-prompt.md
+++ b/.claude/references/patterns/pattern-higher-order-prompt.md
@@ -2,6 +2,7 @@
 slug: higher-order-prompt
 display_name: "Higher-Order Prompt"
 one_liner: "A prompt that takes other prompts (agent identities) as parameters, separating fixed orchestration logic from variable agent configuration."
+intel_date: null
 slots:
   pattern_id: "## Pattern ID"
   quick_summary: "## Quick Summary"

--- a/.claude/references/patterns/pattern-hitl-protocol.md
+++ b/.claude/references/patterns/pattern-hitl-protocol.md
@@ -2,6 +2,7 @@
 slug: hitl-protocol
 display_name: "HITL Protocol"
 one_liner: "When the orchestrator encounters a decision that automated retry cannot resolve, it pauses execution and bounces back to the human for guidance before resuming."
+intel_date: null
 slots:
   pattern_id: "## Pattern ID"
   quick_summary: "## Quick Summary"

--- a/.claude/references/patterns/pattern-hydration-pattern.md
+++ b/.claude/references/patterns/pattern-hydration-pattern.md
@@ -2,6 +2,7 @@
 slug: hydration-pattern
 display_name: "Hydration Pattern"
 one_liner: "Serialize orchestration state into the spec file as a structured checkpoint, enabling cross-session resume by rehydrating from the checkpoint and skipping completed work."
+intel_date: null
 slots:
   pattern_id: "## Pattern ID"
   quick_summary: "## Quick Summary"

--- a/.claude/references/patterns/pattern-iterative-refinement.md
+++ b/.claude/references/patterns/pattern-iterative-refinement.md
@@ -2,6 +2,7 @@
 slug: iterative-refinement
 display_name: "Iterative Refinement"
 one_liner: "A human-in-the-loop gate between plan generation and plan execution that lets users approve, modify, or cancel before any agent is dispatched."
+intel_date: null
 slots:
   pattern_id: "## Pattern ID"
   quick_summary: "## Quick Summary"

--- a/.claude/references/patterns/pattern-parallel-dispatch.md
+++ b/.claude/references/patterns/pattern-parallel-dispatch.md
@@ -2,6 +2,7 @@
 slug: parallel-dispatch
 display_name: "Parallel Dispatch"
 one_liner: "When multiple tasks in the same wave have no dependencies between them, dispatch their builders concurrently instead of sequentially to reduce wall-clock time."
+intel_date: null
 slots:
   pattern_id: "## Pattern ID"
   quick_summary: "## Quick Summary"

--- a/.claude/references/patterns/pattern-plugin-architecture.md
+++ b/.claude/references/patterns/pattern-plugin-architecture.md
@@ -2,6 +2,7 @@
 slug: plugin-architecture
 display_name: "Plugin Architecture"
 one_liner: "Extract a working prototype from a project's .claude/ directory into a distributable marketplace plugin while keeping the prototype repo as an educational snapshot."
+intel_date: null
 slots:
   pattern_id: "## Pattern ID"
   quick_summary: "## Quick Summary"

--- a/.claude/references/patterns/pattern-ralph-wiggum-loop.md
+++ b/.claude/references/patterns/pattern-ralph-wiggum-loop.md
@@ -2,6 +2,7 @@
 slug: ralph-wiggum-loop
 display_name: "Ralph Wiggum Loop"
 one_liner: "A visual retry loop where the browser validator screenshots, finds issues, the builder fixes them, and the cycle repeats until the validator reports PASS or max iterations are reached."
+intel_date: null
 slots:
   pattern_id: "## Pattern ID"
   quick_summary: "## Quick Summary"

--- a/.claude/references/patterns/pattern-retry-with-resume.md
+++ b/.claude/references/patterns/pattern-retry-with-resume.md
@@ -2,6 +2,7 @@
 slug: retry-with-resume
 display_name: "Retry with Resume"
 one_liner: "On validation failure, re-dispatch the Builder with full conversation context and specific rejection feedback, while always dispatching the Validator fresh."
+intel_date: null
 slots:
   pattern_id: "## Pattern ID"
   quick_summary: "## Quick Summary"

--- a/.claude/references/patterns/pattern-spec-as-source-of-truth.md
+++ b/.claude/references/patterns/pattern-spec-as-source-of-truth.md
@@ -2,6 +2,7 @@
 slug: spec-as-source-of-truth
 display_name: "Spec as Source of Truth"
 one_liner: "Write the full orchestration plan to disk before dispatching any agents, and re-read it at each wave boundary to defend against context compaction."
+intel_date: null
 slots:
   pattern_id: "## Pattern ID"
   quick_summary: "## Quick Summary"

--- a/.claude/references/patterns/pattern-spec-hardening.md
+++ b/.claude/references/patterns/pattern-spec-hardening.md
@@ -2,6 +2,7 @@
 slug: spec-hardening
 display_name: "Spec Hardening"
 one_liner: "Rewrite vague task descriptions into concrete, implementation-ready specs with resolved file paths, measurable acceptance criteria, and explicit function signatures before any builder is dispatched."
+intel_date: null
 slots:
   pattern_id: "## Pattern ID"
   quick_summary: "## Quick Summary"

--- a/.claude/references/patterns/pattern-task-dag.md
+++ b/.claude/references/patterns/pattern-task-dag.md
@@ -2,6 +2,7 @@
 slug: task-dag
 display_name: "Task DAG"
 one_liner: "Decompose a multi-task prompt into a directed acyclic graph of tasks with explicit dependency edges, enforced at the task infrastructure level."
+intel_date: null
 slots:
   pattern_id: "## Pattern ID"
   quick_summary: "## Quick Summary"

--- a/.claude/references/patterns/pattern-team-profiles.md
+++ b/.claude/references/patterns/pattern-team-profiles.md
@@ -2,6 +2,7 @@
 slug: team-profiles
 display_name: "Team Profiles"
 one_liner: "Bundle agent identities (builder, validator) into named, switchable configurations resolved at orchestration start via the --team flag."
+intel_date: null
 slots:
   pattern_id: "## Pattern ID"
   quick_summary: "## Quick Summary"

--- a/.claude/references/patterns/pattern-wave-computation.md
+++ b/.claude/references/patterns/pattern-wave-computation.md
@@ -2,6 +2,7 @@
 slug: wave-computation
 display_name: "Wave Computation"
 one_liner: "Group DAG tasks into topologically-sorted execution layers so dependency constraints are respected and independent tasks are eligible for parallelism."
+intel_date: null
 slots:
   pattern_id: "## Pattern ID"
   quick_summary: "## Quick Summary"

--- a/.claude/references/patterns/pattern-worktree-isolation.md
+++ b/.claude/references/patterns/pattern-worktree-isolation.md
@@ -2,6 +2,7 @@
 slug: worktree-isolation
 display_name: "Worktree Isolation"
 one_liner: "Each parallel builder operates in a temporary git worktree so concurrent file writes never conflict, with changes merged back after validation."
+intel_date: null
 slots:
   pattern_id: "## Pattern ID"
   quick_summary: "## Quick Summary"

--- a/.claude/references/proposed-patterns/pattern-agent-hint-observability.md
+++ b/.claude/references/proposed-patterns/pattern-agent-hint-observability.md
@@ -1,0 +1,214 @@
+---
+slug: agent-hint-observability
+display_name: "Agent-Hint Observability"
+one_liner: "Instrument CLIs and services with structured logging that auto-switches between human-readable and machine-parseable output, embedding actionable hints (error codes, next-actions, retryability) so AI agents can diagnose failures and self-correct without parsing prose."
+intel_date: 2026-02-27
+slots:
+  pattern_id: "## Pattern ID"
+  quick_summary: "## Quick Summary"
+  when_to_use: "## When To Use"
+  core_mechanism: "## Core Mechanism"
+  key_rules: "## Key Rules"
+  implementation_notes: "## Implementation Notes"
+  failure_modes: "## Failure Modes"
+  signals_diagnostics: "## Signals & Diagnostics"
+  tradeoffs: "## Tradeoffs"
+  related_patterns: "## Related Patterns"
+  source_anchors: "## Source Anchors"
+---
+
+## Pattern ID
+
+agent-hint-observability
+
+## Quick Summary
+
+Agent-Hint Observability is the practice of instrumenting CLIs and services so that every error, warning, and diagnostic carries machine-readable metadata -- error codes, suggested next-actions, and retryability flags -- alongside human-readable messages. The core enforcement mechanism is tri-modal output: the same tool emits human-friendly text to a TTY, structured JSON Lines to stderr when piped, and a typed JSON envelope on stdout for programmatic consumers. AI agents calling the tool get actionable hints ("retry after 5s", "run auth", "escalate to human") without parsing prose, while humans see familiar colored terminal output. The pattern bridges structured logging (LogTape, Pino, etc.) with an explicit error-action contract inspired by RFC 7807 Problem Details.
+
+## When To Use
+
+- CLI tools consumed by both humans and AI agents -- you need one codebase to serve both audiences
+- Error recovery must be machine-driven -- agents need to branch on "retry", "re-auth", or "escalate" without parsing error text
+- Parallel or multi-step agent workflows where correlating log lines across subtasks requires a shared run ID
+- Debugging failures in agent-invoked tools where the agent currently gets only an opaque error string
+- Libraries that must be logging-silent when used as a dependency but fully observable when run as a CLI
+- Tools where you observe agents hallucinating recovery steps because the error output lacks structured affordances
+- Any service where "most agent observability is just logs + vibes" (r/AI_Agents) and you want to move beyond that
+
+## Core Mechanism
+
+The pattern has three interlocking layers:
+
+**Layer 1: Structured Logging with Auto-Format Switching**
+
+Use a structured logging library (LogTape, Pino, etc.) that treats log entries as data, not strings. Each log call carries a message template with `{placeholder}` properties that become queryable fields in JSON output:
+
+```typescript
+logger.debug('Request {method} {url} (timeout={timeoutMs}ms)', {
+  method: 'GET',
+  url: endpoint,
+  timeoutMs: 5000,
+  ...getLogContext(), // spreads { runId } from AsyncLocalStorage
+})
+```
+
+The sink auto-switches based on output context:
+- **TTY stderr** -- human-readable with ANSI colors and `[prefix]` labels
+- **Piped stderr** -- JSON Lines (one JSON object per line), machine-parseable
+- **`--json` flag** -- forces JSON Lines regardless of TTY detection
+- **`--quiet` flag** -- suppresses all output below `error` level
+
+**Layer 2: Error-Action Contract (Agent Hints)**
+
+Every error response includes machine-readable fields that tell the consuming agent what to do next. This follows the RFC 7807 Problem Details pattern extended with action semantics:
+
+```typescript
+const ERROR_CODE_ACTIONS: Record<string, { action: string; retryable: boolean }> = {
+  E_NETWORK:       { action: 'CHECK_NETWORK',    retryable: false },
+  E_RATE_LIMITED:  { action: 'WAIT_AND_RETRY',    retryable: true  },
+  E_UNAUTHORIZED:  { action: 'RUN_AUTH',          retryable: false },
+  E_STALE_DATA:    { action: 'REFETCH_AND_RETRY', retryable: true  },
+  E_USAGE:         { action: 'FIX_ARGS',          retryable: false },
+  E_RUNTIME:       { action: 'ESCALATE',          retryable: false },
+}
+```
+
+The `writeError` function injects these hints into every JSON error envelope:
+
+```json
+{
+  "status": "error",
+  "message": "Rate limited by Reddit API",
+  "error": {
+    "code": "E_RATE_LIMITED",
+    "action": "WAIT_AND_RETRY",
+    "retryable": true
+  }
+}
+```
+
+The agent reads `action` and `retryable` -- it never parses `message`.
+
+**Layer 3: Context Propagation via AsyncLocalStorage**
+
+A `runId` is generated once at CLI startup and propagated automatically to every log call via `AsyncLocalStorage`. This means all log lines from a single invocation -- across parallel subtasks, retries, and nested function calls -- share the same correlation ID without threading it as a parameter:
+
+```typescript
+const logContext = new AsyncLocalStorage<{ runId: string }>()
+
+export function withContext<T>(ctx: { runId: string }, fn: () => T): T {
+  return logContext.run(ctx, fn)
+}
+
+// At CLI entry:
+withContext({ runId: crypto.randomUUID().slice(0, 8) }, () => runSearch(args))
+```
+
+## Key Rules
+
+1. **stdout is data, stderr is diagnostics.** JSON envelopes and program output go to stdout. Log messages, progress indicators, and error diagnostics go to stderr. Mixing them corrupts both streams -- a real bug (see Anthropic SDK issue #157 where debug logs on stdout broke JSON-RPC).
+
+2. **Every JSON error envelope must include `action` and `retryable` fields.** The agent must never need to parse the human-readable `message` field to decide what to do next. If you add a new error code, you must add its action mapping.
+
+3. **Log format switches automatically based on output context.** TTY gets human-readable; piped/`--json` gets JSON Lines. An env var override (`LOG_FORMAT=text`) ensures test determinism in non-TTY environments.
+
+4. **Libraries are silent by default.** A `getLogger()` call in library code produces zero output until `setupLogging()` is called by the CLI entry point. Library consumers never see unexpected log messages.
+
+5. **Warnings include remediation context.** Every warning answers three questions: (1) what happened, (2) what the tool did about it, (3) whether user action is needed. Raw warnings without context alarm users and confuse agents.
+
+6. **`writeError()` owns user-facing errors; `logger.error()` owns diagnostic traces.** Never duplicate the same error message in both channels. The user sees "Search failed" on stderr via `writeError()`. The log trace carries the structured context (retry count, response codes, timing) via `logger.error()`.
+
+7. **Shutdown is guaranteed.** `shutdownLogging()` runs on every exit path via try/finally (normal, error) and SIGINT handler. It is idempotent -- safe to call before setup, after failed setup, or multiple times.
+
+## Implementation Notes
+
+**Sink selection logic:**
+
+```typescript
+function shouldUseJsonLogs(options: LoggingOptions): boolean {
+  if (process.env.LOG_FORMAT === 'text') return false
+  if (process.env.LOG_FORMAT === 'json') return true
+  if (options.json) return true
+  return !process.stderr.isTTY
+}
+```
+
+**Fingers-crossed buffering (advanced):**
+
+For default mode (no flags), buffer all log messages in memory and only flush if an `error`-level event fires. Users get zero noise on success but the full debug trace on failure:
+
+```typescript
+fingersCrossed(baseSink, {
+  triggerLevel: 'error',
+  maxBufferSize: 500,
+})
+```
+
+This is powerful but adds complexity -- defer it until you have evidence that users need retroactive debug traces.
+
+**Logger category hierarchy:**
+
+Namespace loggers by module so you can enable per-module debug logging later:
+
+```
+app                    # Root
+├── app.cli            # Arg parsing, entry/exit
+├── app.cache          # Cache hits, misses, stale fallbacks
+├── app.http           # HTTP retries, rate limits
+├── app.search         # Search orchestration
+│   ├── app.search.reddit
+│   └── app.search.x
+└── app.auth           # Authentication flows
+```
+
+**ProgressDisplay interaction:**
+
+Animated spinners and structured logs interleave badly on stderr. Suppress spinners when `--debug` or `--quiet` is active:
+
+| Flag | Progress Mode | Log Level |
+|------|--------------|-----------|
+| (none) | animated | warning |
+| `--debug` | off | debug |
+| `--quiet` | off | error |
+
+**Status commands as agent primitives:**
+
+Beyond error hints, expose a `status` subcommand that returns a `diagnosis` and `nextAction` in its JSON payload. An agent calling `tool status --json` gets `{ "diagnosis": "needs-auth", "nextAction": "RUN_AUTH" }` and can branch without any string parsing.
+
+## Failure Modes
+
+- **Stdout/stderr mixing:** Debug logs written to stdout corrupt the JSON envelope. Agents parse a hybrid blob and fail silently. This is a correctness bug, not a cosmetic issue -- the Anthropic SDK had exactly this problem (issue #157).
+- **Missing action mappings:** A new error code is added without an `ERROR_CODE_ACTIONS` entry. The agent gets `action: undefined` and falls through to a default that may be wrong. Mitigate with a fallback (`action: 'ESCALATE', retryable: false`) and a lint rule that requires every error code to have a mapping.
+- **Warnings without remediation context:** A bare "Cache write failed" warning causes the user to panic and the agent to attempt unnecessary recovery. Always answer: what happened, what the tool did, and whether action is needed.
+- **TTY detection mismatch in tests:** Tests run via `spawnSync()` (non-TTY) get JSON Lines format unexpectedly, breaking assertions written for human-readable output. The `LOG_FORMAT=text` env var override exists precisely for this.
+- **Fingers-crossed buffer overflow:** If a run generates more log messages than `maxBufferSize` before an error, the oldest are silently dropped. Size the buffer for your typical run (e.g., 200-500 messages).
+- **AsyncLocalStorage context leak:** If a `Promise.all()` branch leaks a promise that resolves after the `withContext()` scope closes, its logs lose the `runId`. Non-critical -- logs still emit, just without the correlation ID.
+
+## Signals & Diagnostics
+
+- **Pattern is needed:** Agents calling your CLI get opaque error strings and hallucinate recovery steps. Debugging agent-invoked failures requires re-running with source code changes. You have multiple disconnected debug systems (env vars, flags, `console.error`). Users say "it failed but I don't know why."
+- **Pattern is working:** Agents branch on `action` and `retryable` fields without parsing error text. `--debug` produces a complete structured trace. JSON Lines output is parseable by `jq` and downstream tooling. All log lines from one run share a `runId`. Default mode produces zero diagnostic noise on success.
+- **Pattern is failing:** Agents still parse `message` strings because `action` fields are missing or wrong. Stdout contains log messages mixed with data. Tests are flaky because log format varies between TTY and non-TTY. Warnings lack remediation context and trigger false alarms.
+
+## Tradeoffs
+
+**Gain:** AI agents can self-correct based on structured error metadata without parsing prose. Humans get the same familiar CLI experience with colored terminal output. A single codebase serves three consumers (human, script, agent) via automatic format switching. Debugging agent-invoked failures drops from "edit source, rebuild, re-run" to `--debug`. The error-action contract serves as executable documentation of the tool's failure modes and recovery paths. Context propagation via `runId` enables log correlation across parallel subtasks without parameter threading.
+
+**Cost:** Every new error code requires a corresponding action mapping -- this is ongoing maintenance. The structured logging library is a new dependency (though LogTape is 5.3 KB with zero transitive deps). The three-output-mode logic (TTY detection, format switching, progress display suppression) adds real complexity to the CLI entry point. Fingers-crossed buffering, while powerful, is hard to reason about and test. The pattern front-loads significant design work that only pays off when your tool is actually consumed by agents -- if it's human-only, a simpler logging setup suffices.
+
+## Related Patterns
+
+- **context-engineering** -- observability feeds the context agents need to self-correct; agent hints are a form of pre-processed context that reduces agent reasoning load
+- **self-reflecting-analytics** -- agents summarizing their own execution traces builds on the structured logs this pattern produces
+- **no-fake-no-mock** -- real structured output is tested end-to-end; the log invariant tests (no logs in stdout, clean stderr in quiet mode) are a form of no-fake testing
+- **three-layer-influence** -- agent hints are machine-readable influence at the tool layer; the error-action contract is how tools influence agent behavior without natural language
+
+## Source Anchors
+
+- [Designing API Error Messages for AI Agents -- Nordic APIs](https://nordicapis.com/designing-api-error-messages-for-ai-agents/) -- RFC 7807 Problem Details for agents; "AI agents rely entirely on explicit semantics and clear affordances to reason about next steps, and without this, they can behave unpredictably"; recovery paths via HATEOAS links, `retry_after` timing, and `doc_uri` references
+- [Keep the Terminal Relevant: Patterns for AI Agent-Driven CLIs -- InfoQ](https://www.infoq.com/articles/ai-agent-cli/) -- tri-modal output, semantic exit codes, MCP integration; "Human and agent interfaces require fundamentally different interaction models, not optional enhancements"; AWS CLI v2 cautionary tale on pager breaking CI
+- [Structured logging -- LogTape](https://logtape.org/manual/struct) -- `{placeholder}` properties as structured fields; JSON Lines formatter for machine parsing; zero-dependency, library-first no-op default
+- [Get structured output from agents -- Anthropic Agent SDK](https://platform.claude.com/docs/en/agent-sdk/structured-outputs) -- `subtype` field on result messages ("success" or "error_max_structured_output_retries") as precedent for machine-readable result codes that agents branch on
+- [@benhylak on X](https://x.com/benhylak/status/2026712861666587086) (412 likes, 30 reposts) -- "today, we're introducing self diagnostics: the first ever way for agents to proactively self-report issues they encounter"
+- [@rauchg/Vercel on X](https://x.com/rauchg/status/2021409454047232430) (483 likes, 27 reposts) -- shipped `get_runtime_logs` in MCP server + `vc logs --status-code 404 --limit 10` as agent primitives; "Just ask Claude Code to fix your crashes"
+- [Observability is Broken -- r/AI_Agents](https://www.reddit.com/r/AI_Agents/comments/1qv6wow/observability_is_broken/) (12 comments) -- community consensus: "most 'agent observability' is just logs + vibes"; proposed fix: structured JSON logs, trace IDs, preflight checks, confidence scoring

--- a/.claude/references/proposed-patterns/pattern-arena-mode.md
+++ b/.claude/references/proposed-patterns/pattern-arena-mode.md
@@ -2,6 +2,7 @@
 slug: arena-mode
 display_name: "Arena Mode"
 one_liner: "Dispatch N builders on the same task concurrently, each in its own worktree, then select the best solution -- turning agent non-determinism from a liability into an asset."
+intel_date: 2026-02-26
 slots:
   pattern_id: "## Pattern ID"
   quick_summary: "## Quick Summary"

--- a/.claude/references/proposed-patterns/pattern-arena-mode.md
+++ b/.claude/references/proposed-patterns/pattern-arena-mode.md
@@ -1,0 +1,125 @@
+---
+slug: arena-mode
+display_name: "Arena Mode"
+one_liner: "Dispatch N builders on the same task concurrently, each in its own worktree, then select the best solution -- turning agent non-determinism from a liability into an asset."
+slots:
+  pattern_id: "## Pattern ID"
+  quick_summary: "## Quick Summary"
+  when_to_use: "## When To Use"
+  core_mechanism: "## Core Mechanism"
+  key_rules: "## Key Rules"
+  implementation_notes: "## Implementation Notes"
+  failure_modes: "## Failure Modes"
+  signals_diagnostics: "## Signals & Diagnostics"
+  tradeoffs: "## Tradeoffs"
+  related_patterns: "## Related Patterns"
+  source_anchors: "## Source Anchors"
+---
+
+## Pattern ID
+
+arena-mode
+
+## Quick Summary
+
+Arena Mode runs the same task N times concurrently with different builders -- each in its own worktree -- then selects the best solution by validation score. Unlike parallel-dispatch (which runs DIFFERENT tasks concurrently), arena mode runs IDENTICAL tasks to exploit non-determinism. The speaker deployed 20 agents with one prompt to build a search agent, and every agent found a working solution (20/20) in 20-30 minutes. The pattern turns agent variability from a reliability problem into an optimization strategy: the best solution emerges from competition, not collaboration.
+
+## When To Use
+
+- Tasks where the correct solution path is unclear and exploration is valuable
+- When reliability needs are high and parallel compute is cheap -- run N attempts, keep the best
+- Hard tasks where single-agent success rate is below 70%
+- As the prerequisite for cooperative-refinement -- arena generates N candidates, refinement merges the best parts
+- When you want to test different models or team profiles against the same problem
+- Projects where solution quality matters more than compute cost
+
+## Core Mechanism
+
+Arena mode operates in three phases:
+
+**Phase 1: Concurrent Dispatch**
+- Clone N worktrees from the same base commit
+- Dispatch N builders with identical task descriptions but potentially different models or team profiles
+- Builders run concurrently with zero communication during build
+- Each builder operates in isolation using worktree-isolation pattern
+- All solutions are committed to separate branches
+
+**Phase 2: Independent Validation**
+- Validator runs on each solution independently
+- Score by pass/fail, or by rubric if multiple pass
+- No cross-solution comparison during validation -- validator sees one solution at a time
+
+**Phase 3: Selection**
+- If one passes, use it
+- If multiple pass, select by highest validation score or trigger HITL
+- If none pass, retry the best-scoring candidate or escalate to cooperative-refinement
+- Winning solution is merged to the main branch; other worktrees are archived or deleted
+
+Results from the Tessl experiment: "Every agent finds a solution. This is new. Remembering 2-3 years ago, that wasn't possible." Codex had a slight edge over Claude Code in their tests.
+
+## Key Rules
+
+1. Arena mode is triggered by `--arena` flag or automatically for hard tasks when cooperative-refinement is enabled.
+2. All builders receive identical task descriptions -- no variation in prompts.
+3. Builders may use different models or team profiles to maximize diversity.
+4. No communication between builders during execution -- isolation is enforced by worktree boundaries.
+5. Validation is independent: validator sees one solution at a time, not all N solutions together.
+6. Selection is mechanical: if pass count = 1, use it; if > 1, score by rubric; if 0, retry or escalate.
+7. Worktrees are ephemeral: winning solution is merged, others are deleted to avoid clutter.
+
+## Implementation Notes
+
+Reuse the worktree-isolation pattern: each builder gets its own git worktree cloned from the base commit. The worktree directory is `worktrees/<agent-id>/`. This prevents file system conflicts and allows concurrent writes.
+
+Use heterogeneous builders: vary the model (Sonnet vs Opus vs Codex), team-profile (architecture vs debugging vs testing focus), or temperature setting to maximize diversity.
+
+The orchestrator tracks N dispatch tasks in parallel using Promise.all() or an equivalent concurrency primitive. Each task's AGENT_ID environment variable points to its own worktree.
+
+Validation should be mechanical and identical for all solutions: same acceptance criteria, same rubric. Do not introduce subjective judgment that could skew selection.
+
+If cooperative-refinement is enabled, all N solutions proceed to the refinement phase even if some fail validation. Refinement extracts the best parts from each.
+
+## Failure Modes
+
+- **Insufficient diversity:** All N builders use the same model and team profile, producing near-identical solutions. Wastes compute without improving quality.
+- **Validation inconsistency:** Validator applies different criteria to different solutions, making selection arbitrary.
+- **Worktree leakage:** Builders access files outside their worktree, causing file conflicts or polluting the main branch.
+- **Selection ambiguity:** Multiple solutions pass with identical scores, and the orchestrator has no tiebreaker logic. Causes non-deterministic selection.
+- **Over-provisioning:** Running N=20 when N=3 would suffice. Inflates cost and latency without meaningful quality gain.
+
+## Signals & Diagnostics
+
+- **Pattern is needed:** Single-agent success rate is below 70%, or task is hard and reliability matters.
+- **Pattern is working:** Pass rate across N solutions is >50%, and the best solution scores higher than the average single-agent attempt.
+- **Pattern is failing:** All N solutions fail validation with similar errors -- indicates the task description is broken, not a search problem.
+- **Pattern is over-provisioned:** Solutions converge after N=3; running N=10 produces no new approaches.
+
+## Tradeoffs
+
+**Gain:** Turns non-determinism into an asset. Single-agent reliability of 60% becomes multi-agent reliability of 95% with N=5. Catches edge cases and explores alternative approaches without manual intervention.
+
+**Cost:** N times the compute. A 20-agent arena costs 20x the tokens. Latency is the max of all N runs, not the sum (concurrent), but still longer than a single attempt. Worktree management adds orchestration overhead.
+
+**When to pay:** Hard tasks where solution quality justifies the cost. When failure has high downstream cost (production deploy, API contract change). When parallelizable compute is cheap relative to human debugging time.
+
+## Related Patterns
+
+- **Parallel-Dispatch** -- runs DIFFERENT tasks concurrently; arena runs the SAME task concurrently
+- **Worktree-Isolation** -- technical foundation for arena; each builder needs its own worktree
+- **Cooperative-Refinement** -- the next phase after arena; takes N solutions and merges the best parts
+- **Team-Profiles** -- vary team profiles across builders to maximize diversity
+- **Difficulty-Routing** -- triggers arena automatically for hard tasks
+- **Builder-Validator** -- each arena solution is validated independently using this pattern
+
+## Source Anchors
+
+Community evidence and research:
+- [From Prompts to AGENTS.md: What Survives Across Thousands of Runs](https://www.youtube.com/watch?v=aMwuPa6BnaM) -- AI Native Dev NYC talk by Tessl; 20 agents deployed in parallel, every agent found a working solution
+- [Tessl blog post: From Prompts to AGENTS.md](https://tessl.io/blog/from-prompts-to-agents-md-what-survives-across-thousands-of-runs/) -- arena + cooperative refinement experiment details
+- [Multi-Agent Orchestration for Developers in 2026](https://scopir.com/posts/multi-agent-orchestration-parallel-coding-2026/) -- "give both agents the identical prompt... don't look at one until you've gotten both responses"
+- [@agent_wrapper: open-sourced system for 30 parallel AI coding agents per person](https://x.com/agent_wrapper/status/2024885035774738700) (1,534 likes, 284 reposts)
+- [Claude Code Agent Teams: The Complete Guide 2026](https://claudefa.st/blog/guide/agents/agent-teams) -- mesh communication, ~3-4x token cost
+- [Claude Code's Agent Teams Are Insane -- Cole Medin](https://www.youtube.com/watch?v=-1K_ZWDKpU0) (63,555 views, 1,406 likes)
+- [Claude Code Multi-Agent Orchestration with Opus 4.6, Tmux and Agent Sandboxes -- IndyDevDan](https://www.youtube.com/watch?v=RpUTF_U4kiw) (34,839 views, 1,178 likes)
+- [Stanford Proves Parallel Coding Agents are a Scam](https://www.reddit.com/r/LocalLLaMA/comments/1qou799/stanford_proves_parallel_coding_agents_are_a_scam/) (211 pts, 107 comments) -- counterpoint: CooperBench shows coordination is hard but community argues the benchmark artificially blindfolds agents
+- [Google Research: multi-agent coordination across 180 configurations](https://x.com/GoogleResearch/status/2016621362480382213) (771 likes, 101 reposts) -- +81% on parallelizable tasks, -70% on sequential ones

--- a/.claude/references/proposed-patterns/pattern-command-vs-skill-routing.md
+++ b/.claude/references/proposed-patterns/pattern-command-vs-skill-routing.md
@@ -1,0 +1,207 @@
+---
+slug: command-vs-skill-routing
+display_name: "Command vs Skill Routing"
+one_liner: "Route slash commands to the right format -- simple read-only commands stay as flat .claude/commands/ files; action commands that perform writes or need tool constraints migrate to .claude/skills/<name>/SKILL.md with frontmatter controls like disable-model-invocation and allowed-tools."
+intel_date: 2026-02-27
+slots:
+  pattern_id: "## Pattern ID"
+  quick_summary: "## Quick Summary"
+  when_to_use: "## When To Use"
+  core_mechanism: "## Core Mechanism"
+  key_rules: "## Key Rules"
+  implementation_notes: "## Implementation Notes"
+  failure_modes: "## Failure Modes"
+  signals_diagnostics: "## Signals & Diagnostics"
+  tradeoffs: "## Tradeoffs"
+  related_patterns: "## Related Patterns"
+  source_anchors: "## Source Anchors"
+---
+
+## Pattern ID
+
+command-vs-skill-routing
+
+## Quick Summary
+
+Commands (`.claude/commands/*.md`) and skills (`.claude/skills/*/SKILL.md`) both produce slash commands. They are not competing patterns -- they serve different purposes. Commands are the **simple format**: a flat markdown file with minimal frontmatter (`name`, `description`, `argument-hint`). Skills are the **full-featured format**: a directory with SKILL.md that adds constraint fields (`disable-model-invocation`, `allowed-tools`) and room for references, examples, and tests.
+
+**The routing decision is straightforward:**
+
+| Question | Answer | Use |
+|---|---|---|
+| Does it perform writes, mutations, or side effects? | Yes | Skill |
+| Should Claude be prevented from auto-triggering it? | Yes | Skill |
+| Does it need tool sandboxing (`allowed-tools`)? | Yes | Skill |
+| Does it need reference files, examples, or tests? | Yes | Skill |
+| Is it a simple, read-only prompt with no constraints? | Yes | Command |
+
+Commands are not deprecated. They are the right choice for simple, read-only slash commands where you *want* Claude to be able to auto-invoke them and where no tool constraints are needed. Migration only applies when a command needs capabilities that the command format cannot express.
+
+## When To Use
+
+**Use commands (`.claude/commands/*.md`) when:**
+- The slash command is a simple, read-only prompt (e.g., "explain this codebase", "summarize recent changes")
+- Auto-invocation by Claude is desirable or harmless
+- No tool constraints are needed
+- No reference files, examples, or test fixtures are associated with the command
+
+**Migrate to skills (`.claude/skills/*/SKILL.md`) when:**
+- The command performs writes, mutations, or side effects (reconciliation, deployment, data migration)
+- You need to prevent Claude from auto-invoking the workflow (`disable-model-invocation: true`)
+- You want to constrain which tools the command can use (`allowed-tools`)
+- The command needs associated reference files, examples, or tests (the directory-per-skill structure supports this)
+- Your context budget is tight and the command's description is consuming tokens unnecessarily (disabled skills are excluded from the prompt)
+
+## Core Mechanism
+
+**Two formats, one slash-command system:**
+
+Both formats produce slash commands that users invoke identically (`/name`). The difference is what the format can express:
+
+```
+.claude/commands/explain-codebase.md     # Simple format: flat file, minimal frontmatter
+.claude/skills/xero-reconcile/SKILL.md   # Full format: directory, constraint frontmatter
+```
+
+| Frontmatter field | Commands | Skills |
+|---|---|---|
+| `name` | Yes | Yes |
+| `description` | Yes | Yes |
+| `argument-hint` | Yes | Yes |
+| `disable-model-invocation` | No | Yes |
+| `allowed-tools` | No | Yes |
+| Reference files alongside | No (flat file) | Yes (directory) |
+
+**When migration is needed, it is a four-step transform per command file:**
+
+**Step 1: Create skill directory and SKILL.md**
+
+```
+.claude/commands/xero-reconcile.md  -->  .claude/skills/xero-reconcile/SKILL.md
+```
+
+The directory-per-skill structure enables future additions (references/, examples/, tests/) without restructuring.
+
+**Step 2: Transform frontmatter**
+
+Commands frontmatter (before):
+```yaml
+---
+name: xero-reconcile
+description: Reconcile Xero bank transactions for a quarter
+argument-hint: "[quarter|all]"
+---
+```
+
+Skills frontmatter (after):
+```yaml
+---
+name: xero-reconcile
+description: Reconcile Xero bank transactions for a quarter
+argument-hint: "[quarter|all]"
+disable-model-invocation: true
+allowed-tools: Bash(bun run xero-cli *)
+---
+```
+
+Key additions:
+- `disable-model-invocation: true` -- Claude cannot auto-trigger this skill; user must invoke via `/xero-reconcile`
+- `allowed-tools: Bash(bun run xero-cli *)` -- only xero-cli bash commands are permitted during skill execution
+
+**Step 3: Move body content verbatim**
+
+The body (everything below frontmatter) copies unchanged. No rewriting, no restructuring. The skill's instructions, steps, and references remain identical.
+
+**Step 4: Delete old command file**
+
+Remove the `.claude/commands/<name>.md` file. If the commands/ directory is now empty, git will stop tracking it automatically.
+
+**Slash-command UX is preserved:**
+
+`/xero-reconcile` and `/xero-review` resolve identically whether the source is a command file or a skill directory. The user experience is unchanged.
+
+## Key Rules
+
+1. **Body content moves verbatim.** Do not rewrite, restructure, or "improve" the body during migration. The migration is a frontmatter transform, not a content rewrite. Mixing concerns makes the migration harder to review and introduces risk.
+2. **`disable-model-invocation: true` for any skill that performs writes or mutations.** If the skill can create, update, or delete data, it must not be auto-invocable. The user must explicitly trigger it via slash command.
+3. **`allowed-tools` should be as narrow as possible.** Prefer `Bash(bun run xero-cli *)` over `Bash(*)`. The wildcard should be within the tool's own command namespace, not a blanket allow.
+4. **Reference file paths stay relative.** If the command body says "read `.claude/skills/xero-cli/references/command-reference.md`", keep that path unchanged. Skills resolve relative paths from the project root.
+5. **One commit per migration batch.** Migrate related commands together (e.g., all xero-* commands in one commit) so the diff is reviewable as a cohesive change.
+6. **Verify slash commands still resolve after migration.** The skill system resolves `/name` by searching both commands/ and skills/ directories. After deleting the command file, verify the skill file is picked up.
+
+## Implementation Notes
+
+**Routing new slash commands:**
+
+When creating a new slash command, choose the format based on the routing table in Quick Summary. Default to commands -- only reach for skills when you need constraint frontmatter or a reference directory. Over-migrating simple commands to skills adds unnecessary directory nesting.
+
+**Identifying existing commands that need migration:**
+
+Migrate first (highest value):
+- Commands that perform writes or mutations (reconcile, deploy, migrate)
+- Commands that reference external APIs or services
+- Commands with complex multi-step workflows
+
+Leave as commands (they're fine where they are):
+- Pure read-only informational commands
+- Simple prompts with no side effects
+- Commands where auto-invocation by Claude is desirable
+
+**Directory structure convention:**
+
+```
+.claude/skills/
+  xero-cli/              # Reference skill (user-invocable: false, auto-loads for context)
+  xero-reconcile/        # Action skill (disable-model-invocation: true)
+  xero-review/           # Action skill (disable-model-invocation: true)
+```
+
+The three-tier pattern emerges naturally:
+- **Reference skills** -- auto-load context, no user invocation needed (`user-invocable: false`)
+- **Action skills** -- user-invoked only, constrained tools (`disable-model-invocation: true`)
+- **Knowledge skills** -- model can auto-invoke for context (no disable flags)
+
+**Cross-references between skills:**
+
+Action skills often reference other skills' documentation. For example, `xero-reconcile` says "read `.claude/skills/xero-cli/references/command-reference.md`". These cross-references are essential because the referenced skill's full content only auto-loads at Claude's discretion. The "read" instructions make the dependency explicit and deterministic.
+
+**Token budget impact:**
+
+When `disable-model-invocation: true` is set, the skill's description is excluded from the system prompt's skill listing. For skills with long descriptions, this saves tokens on every turn. The body content is only loaded when the user invokes the slash command.
+
+## Failure Modes
+
+- **Forgetting `disable-model-invocation: true` on write skills.** The skill migrates successfully but Claude can now auto-trigger a reconciliation workflow mid-conversation. This is worse than the command pattern, which also lacked the flag but had no explicit control mechanism either.
+- **Overly broad `allowed-tools`.** Using `Bash(*)` instead of `Bash(bun run xero-cli *)` removes the sandboxing benefit entirely. The skill can execute arbitrary bash commands.
+- **Rewriting body content during migration.** Mixing content changes with the migration makes the diff unreviewable. If the body needs improvements, do them in a separate commit after the migration.
+- **Broken cross-references.** If the command body referenced files relative to its old location, and those paths were not project-root-relative, they may break after migration. Always use project-root-relative paths.
+- **Orphaned command directory.** Forgetting to delete the old command file leaves two definitions for the same slash command. Behavior depends on resolution order and may be unpredictable.
+- **Missing slash-command verification.** Not testing that `/name` still resolves after migration. The skill file might have a typo in the `name` frontmatter field.
+
+## Signals & Diagnostics
+
+- **Pattern is needed:** Action commands exist in `.claude/commands/` that perform writes. Claude occasionally auto-triggers these commands during conversation. There is no clear routing decision for where new slash commands should live.
+- **Pattern is working:** Simple read-only commands live in `.claude/commands/`. Action workflows live under `.claude/skills/` with `disable-model-invocation: true` and `allowed-tools` constraints. New slash commands are routed to the correct format without debate. Claude never auto-triggers reconciliation or review workflows. Slash commands resolve correctly from both locations.
+- **Pattern is failing:** Everything is migrated to skills regardless of complexity (over-migration). Or: action commands remain as flat command files without constraints. Migrated skills lack `disable-model-invocation` and Claude auto-triggers them. Old command files were not deleted, creating duplicate definitions.
+
+## Tradeoffs
+
+**Gain:** Clear routing decision for where new slash commands belong. Action commands gain invocation control (`disable-model-invocation`), tool sandboxing (`allowed-tools`), context budget savings (disabled skill descriptions excluded from prompt), and directory structure for references/tests. Simple read-only commands stay as flat files with zero overhead. Both formats produce identical slash-command UX.
+
+**Cost:** Two formats to understand instead of one. The routing decision adds a small cognitive step when creating new slash commands. The directory-per-skill structure adds nesting compared to flat command files. Skills that reference other skills' documentation create implicit coupling -- a renamed reference file silently breaks the dependent skill. Over-migration (moving simple commands to skills unnecessarily) adds directory bloat without benefit.
+
+## Related Patterns
+
+- **skill-bootstrapping** -- new action skills should be created directly as SKILL.md files with proper frontmatter; this pattern covers routing decisions for new commands vs skills and migrating existing commands that need constraint frontmatter
+- **three-layer-influence** -- skills are one of three influence layers (CLAUDE.md, skills, hooks); migrating commands to skills moves them into the correct layer with proper constraint mechanisms
+- **context-engineering** -- `disable-model-invocation: true` reduces context budget by excluding skill descriptions; this is a form of minimum viable context optimization
+- **rules-as-exploration-enablers** -- `allowed-tools` constraints in skill frontmatter are rules that define the boundary of what the skill can do, enabling safe exploration within those boundaries
+
+## Source Anchors
+
+- [Claude Code Skills Documentation](https://docs.anthropic.com/en/docs/claude-code/skills) -- official docs on SKILL.md anatomy, frontmatter fields (`name`, `description`, `argument-hint`, `disable-model-invocation`, `allowed-tools`), and skill resolution
+- [Claude Code Custom Slash Commands](https://docs.anthropic.com/en/docs/claude-code/slash-commands) -- command file format (.claude/commands/*.md); the simple format for read-only slash commands with minimal frontmatter
+- [Complete Guide to Skills.md in 2026](https://www.flex.com.ph/articles/complete-guide-to-skillsmd-in-2026) -- community guide covering YAML frontmatter (~100 tokens metadata), `disable-model-invocation`, `allowed-tools` patterns, and progressive disclosure via references/
+- [Anthropic Docs: Skills vs Commands](https://docs.anthropic.com/en/docs/claude-code/skills#custom-slash-commands) -- skills and commands unified; skills offer frontmatter constraints that commands lack
+- [Claude Code Changelog - Skills Launch](https://docs.anthropic.com/en/docs/claude-code/changelog) -- skills system introduction with `disable-model-invocation` and `allowed-tools` as key differentiators from legacy commands
+- Practical evidence: `tax-return` repo migration of `xero-reconcile` and `xero-review` from `.claude/commands/` to `.claude/skills/` (commit on `feat/xero-cli-agent-native` branch) -- body content moved verbatim, frontmatter gained `disable-model-invocation: true` and `allowed-tools: Bash(bun run xero-cli *)`

--- a/.claude/references/proposed-patterns/pattern-community-pattern-mining.md
+++ b/.claude/references/proposed-patterns/pattern-community-pattern-mining.md
@@ -2,6 +2,7 @@
 slug: community-pattern-mining
 display_name: "Community Pattern Mining"
 one_liner: "Crawl, classify, and index AGENTS.md and CLAUDE.md files from thousands of GitHub repos into a vector database, then use RAG retrieval to bootstrap better agent configurations from community-proven patterns."
+intel_date: 2026-02-26
 slots:
   pattern_id: "## Pattern ID"
   quick_summary: "## Quick Summary"

--- a/.claude/references/proposed-patterns/pattern-community-pattern-mining.md
+++ b/.claude/references/proposed-patterns/pattern-community-pattern-mining.md
@@ -1,0 +1,135 @@
+---
+slug: community-pattern-mining
+display_name: "Community Pattern Mining"
+one_liner: "Crawl, classify, and index AGENTS.md and CLAUDE.md files from thousands of GitHub repos into a vector database, then use RAG retrieval to bootstrap better agent configurations from community-proven patterns."
+slots:
+  pattern_id: "## Pattern ID"
+  quick_summary: "## Quick Summary"
+  when_to_use: "## When To Use"
+  core_mechanism: "## Core Mechanism"
+  key_rules: "## Key Rules"
+  implementation_notes: "## Implementation Notes"
+  failure_modes: "## Failure Modes"
+  signals_diagnostics: "## Signals & Diagnostics"
+  tradeoffs: "## Tradeoffs"
+  related_patterns: "## Related Patterns"
+  source_anchors: "## Source Anchors"
+---
+
+## Pattern ID
+
+community-pattern-mining
+
+## Quick Summary
+
+Community Pattern Mining extracts agent configuration files (AGENTS.md, CLAUDE.md, Skills.md, README) from 40,000+ GitHub repos, classifies them by project type and lifecycle stage using LLMs, stores them in a vector database with metadata filters, then retrieves and reranks relevant examples on demand to bootstrap new agent configurations. The speaker's key finding: "The prompts these agents come up with are better than the prompts we come up with. And if they have the chance to look at other good solutions, it improves the quality even more." This pattern is meta-prompting at scale -- learning from community behavior to improve agent generation.
+
+## When To Use
+
+- When generating a new AGENTS.md or CLAUDE.md for a project with no existing configuration
+- When optimizing an existing agent configuration for a specific domain (e.g., frontend vs backend, testing vs deployment)
+- When the agent needs to adapt to a new project type or lifecycle stage (prototype vs production)
+- When you want to surface best practices from the community without manual curation
+- When building a marketplace or recommendation system for agent configurations
+- When tracking adoption trends and evolution of agent configuration patterns over time
+
+## Core Mechanism
+
+The pattern operates in two phases: **indexing** (offline batch process) and **retrieval** (on-demand query).
+
+**Phase 1: Indexing**
+1. **Crawl:** Extract configuration files from GitHub repos via API -- AGENTS.md, CLAUDE.md, Skills.md, README
+2. **Classify:** Use LLMs to tag each file with metadata:
+   - Project type (frontend, backend, CLI, library, fullstack)
+   - Lifecycle stage (prototype, MVP, production, maintenance)
+   - Agentic level (basic automation, task decomposition, multi-agent coordination)
+   - Rules classification (code style, git workflow, testing, deployment)
+   - GenAI focus (agentic, CLI tools, SDK, infrastructure)
+3. **Index:** Store in vector database (e.g., Pinecone, Weaviate) with:
+   - Embedding of the file content
+   - Metadata filters for query-time filtering
+   - Timestamp for recency ranking
+
+**Phase 2: Retrieval**
+1. **Query:** Agent receives a task to create or improve an agent configuration
+2. **Embed:** Embed the current task context (project type, goals, constraints)
+3. **Retrieve:** Query the vector database with semantic similarity + metadata filters
+4. **Rerank:** Filter by recency, project similarity, and rules type
+5. **Bootstrap:** Agent uses retrieved examples to inform its own configuration generation
+
+Key findings from 40,000+ repos:
+- CLAUDE.md adoption spiked first
+- AGENTS.md followed 4-6 weeks later
+- Skills.md is "exploding right now" -- average 5-6 skills per project
+- 1.6% of all repos have AGENTS.md, but 33% among AI config-enabled projects
+
+## Key Rules
+
+1. Crawling must respect GitHub API rate limits and robots.txt -- do not scrape aggressively.
+2. Classification must be automated via LLMs -- manual tagging does not scale to 40K+ files.
+3. Vector database must support metadata filtering -- pure semantic search without filters produces irrelevant results.
+4. Retrieval must be filtered by recency -- old patterns may reference deprecated tools or APIs.
+5. Retrieved examples are suggestions, not templates -- agent must adapt patterns to the current project's constraints.
+6. Index must be updated regularly (weekly or monthly) to capture new community trends.
+7. Privacy: only index public repos; do not store sensitive or proprietary configuration files.
+
+## Implementation Notes
+
+**Crawling strategy:** Use GitHub API search with queries like `filename:AGENTS.md` or `filename:CLAUDE.md`. Filter by stars or recent commits to prioritize active projects. Store raw file content + metadata (repo name, stars, last commit date, primary language).
+
+**Classification prompts:** Use a lightweight model (Haiku) to tag files. Example prompt: "Classify this AGENTS.md file by project type (frontend/backend/CLI/library/fullstack), lifecycle stage (prototype/MVP/production/maintenance), and agentic level (basic/task-decomposition/multi-agent)." Parse structured output as JSON.
+
+**Vector database schema:**
+- `embedding`: 1536-dim vector (OpenAI text-embedding-3-small or equivalent)
+- `content`: raw file text
+- `metadata`: JSON object with `project_type`, `lifecycle_stage`, `agentic_level`, `rules_classification`, `repo_stars`, `last_commit_date`, `primary_language`
+
+**Retrieval query:** Embed the current project's description or existing AGENTS.md, then query the DB with cosine similarity + metadata filters. Example: "Find AGENTS.md files from frontend projects in production stage with >100 stars, updated in the last 6 months."
+
+**Reranking:** After vector similarity retrieval, rerank by:
+1. Recency (prefer last 3 months)
+2. Stars (prefer high-engagement repos)
+3. Exact project type match (frontend vs backend)
+4. Rules type overlap (if the current project has git-workflow rules, prefer examples with similar rules)
+
+## Failure Modes
+
+- **Stale index:** Database contains outdated patterns referencing deprecated tools. Agents generate configurations that no longer work.
+- **Overfitting to popular repos:** High-star repos dominate retrieval, causing homogenization. Less common but effective patterns are buried.
+- **Misclassification:** LLM tagger incorrectly labels a backend project as frontend. Retrieval returns irrelevant examples.
+- **No diversity:** All retrieved examples come from the same organization or framework. Agent learns a narrow pattern instead of generalizing.
+- **Privacy leak:** Accidentally index a private repo or a public repo with sensitive information in AGENTS.md (API keys, internal URLs). Must filter by repo visibility.
+
+## Signals & Diagnostics
+
+- **Pattern is needed:** Agent generates generic or ineffective AGENTS.md files because it has no domain-specific examples.
+- **Pattern is working:** Generated configurations reference domain-specific tools and patterns that match the project's actual needs (e.g., frontend projects get Playwright references, backend projects get database migration rules).
+- **Pattern is failing:** Retrieved examples are irrelevant (wrong project type), outdated (reference deprecated tools), or too homogeneous (all from the same framework).
+- **Index is stale:** Agents reference tools or APIs that were deprecated >6 months ago.
+
+## Tradeoffs
+
+**Gain:** Bootstrap high-quality agent configurations from community-proven patterns. Reduce manual configuration effort. Surface best practices automatically. Track adoption trends to identify emerging patterns (Skills.md explosion).
+
+**Cost:** Infrastructure overhead -- crawling 40K+ repos, running LLM classification, maintaining a vector database. Retrieval adds latency to agent initialization. Index must be refreshed regularly to stay relevant.
+
+**When to pay:** Projects where agent configuration quality directly impacts developer productivity. Marketplace or recommendation systems where surfacing relevant examples is core functionality. Research projects tracking adoption of agent configuration patterns over time.
+
+## Related Patterns
+
+- **Skill-Bootstrapping** -- uses retrieved Skills.md examples to generate new skills for the current project
+- **Meta-Prompting** -- community pattern mining is meta-prompting at scale; learning from other agents' configurations
+- **Hierarchical-Persistent-Memory** -- stores classification metadata hierarchically for efficient filtering
+- **Self-Reflecting-Analytics** -- tracks which retrieved patterns led to successful agent configurations, improving reranking over time
+
+## Source Anchors
+
+Community evidence and research:
+- [From Prompts to AGENTS.md: What Survives Across Thousands of Runs](https://www.youtube.com/watch?v=aMwuPa6BnaM) -- AI Native Dev NYC talk by Tessl; 40K+ repo analysis, vector database for AGENTS.md retrieval
+- [Tessl blog post: From Prompts to AGENTS.md](https://tessl.io/blog/from-prompts-to-agents-md-what-survives-across-thousands-of-runs/) -- adoption curves: CLAUDE.md first, AGENTS.md followed, Skills.md exploding
+- [AGENTS.md Files: AI Agent Configuration -- Emergent Mind](https://www.emergentmind.com/topics/agents-md-files) -- 1.6% of repos overall, 33% among AI config-enabled projects; median ~336 words, ~142 lines
+- [Evaluating AGENTS.md: Are Repository-Level Context Files Helpful for Coding Agents?](https://arxiv.org/abs/2602.11988) -- ETH Zurich; tested 4 coding agents across 138 repos and 5,694 PRs
+- [Stop Using /init for AGENTS.md -- Addy Osmani](https://addyosmani.com/blog/agents-md/) -- "auto-generated content isn't useless, it's redundant"
+- [Support AGENTS.md -- Issue #6235 -- anthropics/claude-code](https://github.com/anthropics/claude-code/issues/6235) (2,838+ upvotes) -- 20,000+ open-source projects using AGENTS.md
+- [Complete Guide to Skills.md in 2026](https://www.flex.com.ph/articles/complete-guide-to-skillsmd-in-2026) -- Skills.md adoption exploding; YAML frontmatter for metadata
+- [@dani_avila7: Almost 40K downloads across just 3 Claude Code agents](https://x.com/dani_avila7/status/2017096001232781477) (1,441 likes, 138 reposts) -- evidence of template distribution at scale

--- a/.claude/references/proposed-patterns/pattern-context-engineering.md
+++ b/.claude/references/proposed-patterns/pattern-context-engineering.md
@@ -1,0 +1,150 @@
+---
+slug: context-engineering
+display_name: "Context Engineering"
+one_liner: "Actively manage the quality and composition of an agent's context window through controlled handoffs, context surgery, and spec-file re-reads -- because context degradation directly determines agent capability."
+slots:
+  pattern_id: "## Pattern ID"
+  quick_summary: "## Quick Summary"
+  when_to_use: "## When To Use"
+  core_mechanism: "## Core Mechanism"
+  key_rules: "## Key Rules"
+  implementation_notes: "## Implementation Notes"
+  failure_modes: "## Failure Modes"
+  signals_diagnostics: "## Signals & Diagnostics"
+  tradeoffs: "## Tradeoffs"
+  related_patterns: "## Related Patterns"
+  source_anchors: "## Source Anchors"
+---
+
+## Pattern ID
+
+context-engineering
+
+## Quick Summary
+
+Context Engineering is the active management of an agent's context window quality and composition. Three core techniques: (1) ESC-ESC Context Surgery -- edit conversation history retroactively to remove wrong turns and fix misunderstandings; (2) Controlled Handoffs over Auto-Compaction -- manually summarize, review, and hand verified summaries to fresh sessions instead of relying on intransparent auto-compression; (3) Wave-Boundary Spec Re-reads -- the orchestrator re-reads the spec file from disk at every wave boundary, defending against context compaction evicting the task graph. The underlying principle: context quality directly determines agent capability.
+
+## When To Use
+
+- Long-running orchestration sessions where context naturally degrades over many turns
+- Multi-wave execution where the task graph must remain available despite compaction
+- Recovery from wrong-turn scenarios where the agent pursued an incorrect path
+- Handoffs between agents where context must be filtered and summarized
+- Situations where auto-compaction is too opaque or unpredictable
+- Any session where you observe declining agent performance despite clear instructions
+- Minimum viable context optimization -- reducing token count while preserving high-signal information
+
+## Core Mechanism
+
+**ESC-ESC Context Surgery (CLI Agents):**
+
+In CLI-based agents (like Claude CLI or Tessl), double-escape opens an editor showing the full conversation history. Edit the history directly -- rephrase prompts, delete wrong turns, correct misunderstandings, remove redundant exchanges. Save and close. The agent continues with the corrected history as if the mistakes never happened.
+
+**Controlled Handoffs over Auto-Compaction:**
+
+Auto-compaction algorithms are intransparent -- you don't know what was kept or discarded. Instead: (1) ask the current agent to summarize the session state, decisions made, and outstanding issues; (2) review the summary and edit it if necessary; (3) start a fresh session and provide the verified summary as context. This makes the handoff explicit and auditable.
+
+**Wave-Boundary Spec Re-reads:**
+
+The orchestrator re-reads the spec file from disk at the start of every wave. This defends against context compaction evicting the task graph, task descriptions, or acceptance criteria. The spec is the source of truth; re-reading it ensures the agent always has access to the full task structure regardless of compaction.
+
+**Minimum Viable Context (Anthropic):**
+
+Find the smallest possible set of high-signal tokens that maximize the likelihood of the desired outcome. Remove redundant tool outputs, verbose explanations, and repeated information. Preserve architectural decisions, unresolved bugs, and implementation details. The goal is density, not volume.
+
+**Frequent Intentional Compaction (HumanLayer FIC):**
+
+Deliberately structure how you feed context to the AI. Instead of a single long session, break work into phases and explicitly reset context between phases with a curated summary. This prevents degradation from accumulating unchecked.
+
+## Key Rules
+
+1. Context degradation is not theoretical -- agent capability visibly declines as the context fills or when wrong paths are taken.
+2. Auto-compaction is intransparent -- you cannot audit what was kept or discarded. Prefer manual handoffs when session state matters.
+3. Spec files and task graphs should be re-read from disk at wave boundaries, not assumed to be in context.
+4. Context surgery (editing history) is a legitimate debugging technique, not a hack -- use it to remove unproductive exchanges.
+5. Minimum viable context is the goal -- every token should contribute to the desired outcome. Verbose explanations and redundant outputs are noise.
+6. When an agent's performance degrades mid-session, check context length and wrong-turn history before assuming the model is incapable.
+7. Controlled handoffs should include: session summary, decisions made, unresolved issues, and next steps. The receiving agent should confirm understanding before proceeding.
+
+## Implementation Notes
+
+**ESC-ESC in CLI Agents:**
+
+If the agent pursues a wrong path, press ESC twice to open the conversation editor. Delete the incorrect exchanges or rephrase the prompt that led to the wrong turn. Save and exit. The agent resumes with the corrected history.
+
+**Wave-Boundary Re-reads in Orchestrator:**
+
+```typescript
+async function executeWave(waveNumber: number, tasks: Task[]) {
+  // Re-read spec from disk to defend against compaction
+  const spec = await readSpecFile();
+  const context = buildWaveContext(spec, waveNumber, tasks);
+
+  for (const task of tasks) {
+    await dispatchTask(task, context);
+  }
+}
+```
+
+**Controlled Handoff Protocol:**
+
+1. Ask agent to summarize: "Summarize the current session state, including decisions made, unresolved issues, and blockers."
+2. Review the summary. Edit if incomplete or incorrect.
+3. Start a fresh session: "Continuing from a previous session. Here is the state: [verified summary]. Next steps: [...]"
+4. The fresh agent confirms understanding and proceeds.
+
+**Minimum Viable Context Checklist:**
+
+- Remove redundant tool outputs (multiple reads of the same file)
+- Remove verbose explanations unless they contain decisions
+- Preserve architectural decisions and unresolved bugs
+- Preserve implementation details required for next steps
+- Summarize or remove resolved issues
+
+**Compaction Config (if using auto-compaction):**
+
+If auto-compaction is unavoidable, configure it to preserve high-signal information:
+```json
+{
+  "compaction": {
+    "preserve": ["architectural_decisions", "unresolved_bugs", "implementation_details"],
+    "discard": ["redundant_tool_outputs", "resolved_exchanges"]
+  }
+}
+```
+
+## Failure Modes
+
+- **Invisible Compaction Loss:** Auto-compaction discards critical information (task graph, acceptance criteria) without warning. The agent continues but lacks essential context, producing incorrect outputs.
+- **Wrong-Turn Accumulation:** The agent pursues an incorrect path for many turns. Context fills with unproductive exchanges. Performance degrades. Context surgery is not used; the session becomes unrecoverable.
+- **Unaudited Handoffs:** Auto-compaction hands off to a fresh session with a summary you never reviewed. The summary omits critical details or introduces errors. The fresh agent continues from corrupted state.
+- **Spec Eviction:** The orchestrator assumes the task graph is in context but it was compacted away. The agent loses track of which tasks are pending, completed, or blocked.
+- **Verbose Context Pollution:** High token count but low signal density -- repeated tool outputs, verbose explanations, redundant exchanges. The agent spends context budget on noise instead of signal.
+- **Fragile Session State:** Long-running sessions with no intentional compaction or handoffs. Context fills completely. The agent's performance degrades but the user does not realize context is the cause.
+
+## Signals & Diagnostics
+
+- **Pattern is needed:** Agent performance declines visibly mid-session despite clear instructions. Agent "forgets" decisions made earlier in the session. Context window nears capacity. Retry loops produce different but equally wrong outputs.
+- **Pattern is working:** Wave boundaries trigger spec re-reads (observable in logs). Handoffs include explicit summaries that were reviewed. Agent performance remains stable across long sessions. Context window stays below critical capacity.
+- **Pattern is failing:** Orchestrator loses track of task graph mid-run. Agent repeatedly asks for information that was provided earlier. Performance degrades suddenly after auto-compaction. Fresh sessions inherit corrupted state from unaudited summaries.
+
+## Tradeoffs
+
+**Gain:** Agent capability remains stable across long sessions. Critical information (task graphs, acceptance criteria, architectural decisions) is never lost to compaction. Handoffs are explicit and auditable. Context quality is actively managed instead of passively accumulated.
+
+**Cost:** Manual context surgery and controlled handoffs require user intervention and review. Wave-boundary spec re-reads add token cost and latency. Minimum viable context optimization requires understanding which information is high-signal vs noise. Controlled handoffs are slower than auto-compaction.
+
+## Related Patterns
+
+- **Hydration Pattern** -- orchestrator injects spec and task-graph context into agent dispatch calls
+- **Wave Computation** -- wave boundaries are natural points to re-read spec and reset context
+- **Spec as Source of Truth** -- the spec file is re-read from disk, not assumed to be in context
+- **Self-Reflecting Analytics** -- agents summarize session state before handoffs, enabling auditable transitions
+
+## Source Anchors
+
+- [From Prompts to AGENTS.md: What Survives Across Thousands of Runs](https://www.youtube.com/watch?v=aMwuPa6BnaM) -- AI Native Dev NYC talk by Tessl; ESC-ESC context surgery, controlled handoffs vs auto-compaction, "when the context fills or when you walk the wrong paths, the intelligence of these agents degrades"
+- [Tessl blog post: From Prompts to AGENTS.md](https://tessl.io/blog/from-prompts-to-agents-md-what-survives-across-thousands-of-runs/) -- "handoffs over auto-compaction" principle documented
+- [Effective context engineering for AI agents - Anthropic Engineering](https://www.anthropic.com/engineering/effective-context-engineering-for-ai-agents) -- "minimum viable context"; compaction preserves "architectural decisions, unresolved bugs, and implementation details while discarding redundant tool outputs"
+- [Getting AI to Work in Complex Codebases - HumanLayer](https://github.com/humanlayer/advanced-context-engineering-for-coding-agents) (1.5k stars) -- Frequent Intentional Compaction (FIC): "deliberately structuring how you feed context to the AI"
+- [Evaluating AGENTS.md: Are Repository-Level Context Files Helpful for Coding Agents?](https://arxiv.org/abs/2602.11988) -- ETH Zurich; context file redundancy as a form of context pollution

--- a/.claude/references/proposed-patterns/pattern-context-engineering.md
+++ b/.claude/references/proposed-patterns/pattern-context-engineering.md
@@ -2,6 +2,7 @@
 slug: context-engineering
 display_name: "Context Engineering"
 one_liner: "Actively manage the quality and composition of an agent's context window through controlled handoffs, context surgery, and spec-file re-reads -- because context degradation directly determines agent capability."
+intel_date: 2026-02-26
 slots:
   pattern_id: "## Pattern ID"
   quick_summary: "## Quick Summary"

--- a/.claude/references/proposed-patterns/pattern-cooperative-refinement.md
+++ b/.claude/references/proposed-patterns/pattern-cooperative-refinement.md
@@ -1,0 +1,137 @@
+---
+slug: cooperative-refinement
+display_name: "Cooperative Refinement"
+one_liner: "After parallel builders produce independent solutions, cross-pollinate their outputs so each agent can reflect on the other's approach and produce a refined result at a fraction of the initial build cost."
+slots:
+  pattern_id: "## Pattern ID"
+  quick_summary: "## Quick Summary"
+  when_to_use: "## When To Use"
+  core_mechanism: "## Core Mechanism"
+  key_rules: "## Key Rules"
+  implementation_notes: "## Implementation Notes"
+  failure_modes: "## Failure Modes"
+  signals_diagnostics: "## Signals & Diagnostics"
+  tradeoffs: "## Tradeoffs"
+  related_patterns: "## Related Patterns"
+  source_anchors: "## Source Anchors"
+---
+
+## Pattern ID
+
+cooperative-refinement
+
+## Quick Summary
+
+Cooperative Refinement is a post-build phase where parallel builders receive each other's solutions and produce improved versions. After an arena-style parallel dispatch where N builders independently solve the same task, the orchestrator extracts each builder's output (diff and structured summary) and re-dispatches each builder with its own solution plus compressed summaries of the other builders' solutions. The builder reflects on what the other approaches did better, integrates improvements, and produces a refined solution. The refinement budget is substantially smaller than the initial build because the agent adapts rather than reconstructs -- typically 20-40% of Phase 1 token cost. A final validator or scoring pass selects the best refined solution.
+
+## When To Use
+
+- When a task has high uncertainty and multiple valid approaches (architecture decisions, algorithm selection, API design)
+- When running parallel builders on the same task via the arena pattern and you want to improve beyond "pick the best"
+- When the refinement cost (one additional builder dispatch per agent) is justified by the quality gain over raw arena selection
+- When builders use different models or team profiles -- heterogeneous agents produce more diverse solutions to cross-pollinate
+- When the task is complex enough that a single builder's blind spots are likely (5+ files, algorithmic work, cross-module refactors)
+- When the `--refine` flag is passed, or when difficulty-routing tags the task as `hard` and multiple builders are available
+
+## Core Mechanism
+
+Cooperative Refinement runs as an optional phase after parallel dispatch completes and before the final validator pass:
+
+**Phase 1: Arena Build (existing parallel-dispatch pattern)**
+1. Dispatch N builders concurrently on the same task, each in its own worktree.
+2. All builders complete independently -- no communication during build.
+3. Collect each builder's output: the diff against HEAD plus a structured summary of the approach taken.
+
+**Phase 2: Cross-Pollination**
+4. For each builder B_i, construct a refinement context containing:
+   - B_i's own solution (full diff)
+   - For each other builder B_j: a compressed summary of B_j's approach plus key code snippets (not the full diff -- under 1,000 tokens per summary)
+   - A refinement prompt: "Review the other approaches. What did they do better than your solution? What ideas could improve your implementation? Produce a refined version that integrates the best elements while maintaining your solution's strengths."
+5. Re-dispatch each builder with the refinement context. Each builder operates in a fresh worktree from HEAD -- not from its Phase 1 worktree.
+6. Builders produce refined solutions independently. No further cross-pollination rounds.
+
+**Phase 3: Selection**
+7. Run the validator on each refined solution independently.
+8. If exactly one passes: use it.
+9. If multiple pass: score by rubric (code simplicity, test coverage, pattern adherence) or present to the user for selection via HITL.
+10. If none pass: fall back to the best Phase 1 solution and enter the standard retry loop.
+
+**Summary extraction format (generated after Phase 1):**
+
+```
+## Approach: <builder-name>
+- Strategy: <1-2 sentence description>
+- Key decisions: <bullet list of notable implementation choices>
+- Snippets: <2-3 key code blocks, max 50 lines each>
+```
+
+## Key Rules
+
+1. Cross-pollination summaries are compressed -- send approach descriptions and key snippets, not full diffs from other builders. Each summary must be under 1,000 tokens.
+2. Phase 2 builders start from a clean worktree at HEAD, not from their Phase 1 worktree -- this forces the builder to reconstruct with improvements rather than patch.
+3. Maximum one refinement round -- do not iterate. Diminishing returns after the first round make additional rounds cost-ineffective.
+4. The refinement prompt must explicitly ask "What did they do better?" -- without this framing, builders tend to defend their original approach rather than integrate improvements.
+5. If all Phase 2 solutions fail validation, fall back to Phase 1 solutions -- refinement must never discard working solutions.
+6. The pattern is opt-in via a `--refine` flag or triggered automatically when the task's difficulty is `hard` and multiple builders are available.
+7. Homogeneous builders (same model, same team profile) are discouraged -- diversity of approach is the prerequisite for useful cross-pollination.
+
+## Implementation Notes
+
+**Interaction with team-profiles:** Cooperative refinement is most valuable when builders use different models or team profiles. A Codex builder and a Claude builder produce genuinely different approaches. Two identical builders produce near-identical solutions -- cross-pollination adds cost without diversity. The ideal configuration dispatches each arena builder with a different `--team` profile.
+
+**Interaction with difficulty-routing:** When difficulty-routing tags a task as `hard`, cooperative refinement can be triggered automatically if multiple builders are available. Standard tasks skip refinement -- the cost is not justified for straightforward implementations.
+
+**Scoring rubric for Phase 3 selection (when multiple pass):**
+- Fewer lines of code (simpler is better)
+- More comprehensive error handling
+- Better test coverage
+- Closer adherence to existing codebase patterns
+Present scores to the user if the margin is narrow.
+
+**Worktree lifecycle:** Phase 1 worktrees are cleaned up after summaries are extracted. Phase 2 worktrees are created fresh from HEAD. The orchestrator owns all worktree creation and teardown -- builders never manage their own worktrees.
+
+**Event emissions:**
+- `refinement.started` -- after Phase 1 summaries are extracted
+- `refinement.dispatched` -- for each Phase 2 builder launch
+- `refinement.selected` -- when the final solution is chosen, with source (phase-1-fallback or phase-2-refined) and builder identity
+
+## Failure Modes
+
+- **Full diffs sent as cross-pollination context:** Sending complete diffs from all builders blows up the context window. Builders lose focus and produce worse refinements than their Phase 1 originals. Always compress to summaries under 1,000 tokens.
+- **Multiple refinement rounds:** Iterating Phase 2 more than once produces diminishing returns and increasing cost. The first round captures 80%+ of the improvement. Cap at one round.
+- **Homogeneous builders:** Two identical builders (same model, same team profile) produce near-identical solutions. Cross-pollination finds nothing new. Only trigger cooperative refinement when builder diversity exists.
+- **Phase 1 solutions discarded on Phase 2 failure:** If all refined solutions fail validation, the working Phase 1 solutions must be preserved as fallback. Refinement is additive -- never destructive.
+- **Defensive refinement:** Without the "What did they do better?" framing, builders justify their original approach and reject improvements. The prompt must explicitly direct constructive integration, not competitive comparison.
+- **Refinement on standard tasks:** Triggering cooperative refinement for straightforward implementations wastes tokens. The cost overhead (1.4-1.8x additional per builder) is only justified for `hard` tasks where retry rates are high.
+
+## Signals & Diagnostics
+
+- **Pattern is needed:** Arena-style parallel builds consistently produce solutions where each has strengths the others lack; manual review reveals that combining ideas from multiple solutions would yield a better result; the best arena solution scores well but not excellently.
+- **Pattern is working:** Phase 2 refined solutions score higher than their corresponding Phase 1 originals on the validation rubric; refinement token cost is 20-40% of Phase 1 build cost; builders explicitly reference ideas from other solutions in their refined output; `refinement.selected` events show phase-2-refined as source.
+- **Pattern is failing:** Refined solutions score equal to or lower than Phase 1 originals (no improvement); refinement cost exceeds 50% of Phase 1 cost (summaries too large); builders ignore other solutions and reproduce their original approach; `refinement.selected` consistently falls back to phase-1-fallback.
+
+## Tradeoffs
+
+**Gain:** Solutions that combine the best ideas from multiple independent approaches. The refinement cost is substantially lower than a fresh build because agents adapt rather than reconstruct. Heterogeneous builders (different models, different team profiles) produce genuinely diverse approaches that cross-pollinate well. The pattern turns competition (arena -- pick the best) into cooperation (refinement -- improve all from each other).
+
+**Cost:** Requires at least 2 builders per task (arena prerequisite). Adds one refinement round plus a selection pass after the initial build. Total cost for a 2-builder cooperative refinement: approximately 2.4-2.8x a single builder (2x for arena + 0.4-0.8x for refinement). The pattern is only cost-effective when the quality improvement justifies the additional spend -- typically for `hard` tasks where retry rates are high without it.
+
+## Related Patterns
+
+- **parallel-dispatch** -- the execution infrastructure that enables arena-style builds; cooperative refinement is a post-processing phase after parallel dispatch
+- **team-profiles** -- heterogeneous teams maximize the diversity of solutions for cross-pollination; using different team profiles for each arena builder is the ideal configuration
+- **difficulty-routing** -- `hard` tasks are the natural trigger for cooperative refinement; standard tasks skip it
+- **builder-validator** -- the validator runs on each refined solution independently; the standard binary verdict drives selection
+- **iterative-refinement** -- the human-in-the-loop gate; when multiple refined solutions pass validation, the user selects
+- **worktree-isolation** -- Phase 1 and Phase 2 both require isolated worktrees; the orchestrator manages the full lifecycle
+
+## Source Anchors
+
+Community evidence (not yet implemented in orchestrator stages):
+- [From Prompts to AGENTS.md: What Survives Across Thousands of Runs](https://www.youtube.com/watch?v=aMwuPa6BnaM) -- AI Native Dev NYC talk by Tessl; arena + cooperative refinement experiments with 20 agents; refinement budget "much much lower than building up budget"; one agent spontaneously invented an arena pattern inside its own implementation
+- [Tessl blog post: From Prompts to AGENTS.md](https://tessl.io/blog/from-prompts-to-agents-md-what-survives-across-thousands-of-runs/) -- written companion to the talk with additional detail on cooperative refinement results
+- [Google Research: multi-agent coordination across 180 configurations](https://x.com/GoogleResearch/status/2016621362480382213) (771 likes, 101 reposts) -- task-contingent: +81% on parallelizable tasks, -70% on sequential ones
+- [Multi-Agent Orchestration for Developers in 2026](https://scopir.com/posts/multi-agent-orchestration-parallel-coding-2026/) -- Scopir guide: "give both agents the identical prompt... give the one agent the results of the other and ask them to reflect"
+- [@agent_wrapper: open-sourced system for 30 parallel AI coding agents per person](https://x.com/agent_wrapper/status/2024885035774738700) (1,534 likes, 284 reposts)
+- [Claude Code Agent Teams: The Complete Guide 2026](https://claudefa.st/blog/guide/agents/agent-teams) -- mesh communication, mailbox system, ~3-4x token cost
+- [Claude Code's Agent Teams Are Insane -- Cole Medin](https://www.youtube.com/watch?v=-1K_ZWDKpU0) (63,555 views, 1,406 likes) -- practical demo of parallel agent coordination

--- a/.claude/references/proposed-patterns/pattern-cooperative-refinement.md
+++ b/.claude/references/proposed-patterns/pattern-cooperative-refinement.md
@@ -2,6 +2,7 @@
 slug: cooperative-refinement
 display_name: "Cooperative Refinement"
 one_liner: "After parallel builders produce independent solutions, cross-pollinate their outputs so each agent can reflect on the other's approach and produce a refined result at a fraction of the initial build cost."
+intel_date: 2026-02-26
 slots:
   pattern_id: "## Pattern ID"
   quick_summary: "## Quick Summary"

--- a/.claude/references/proposed-patterns/pattern-hierarchical-persistent-memory.md
+++ b/.claude/references/proposed-patterns/pattern-hierarchical-persistent-memory.md
@@ -2,6 +2,7 @@
 slug: hierarchical-persistent-memory
 display_name: "Hierarchical Persistent Memory"
 one_liner: "Place AGENTS.md files at multiple directory levels -- root, component, tool -- so general rules flow down while specific rules stay local, and agents accumulate context by traversing parent directories."
+intel_date: 2026-02-26
 slots:
   pattern_id: "## Pattern ID"
   quick_summary: "## Quick Summary"

--- a/.claude/references/proposed-patterns/pattern-hierarchical-persistent-memory.md
+++ b/.claude/references/proposed-patterns/pattern-hierarchical-persistent-memory.md
@@ -1,0 +1,110 @@
+---
+slug: hierarchical-persistent-memory
+display_name: "Hierarchical Persistent Memory"
+one_liner: "Place AGENTS.md files at multiple directory levels -- root, component, tool -- so general rules flow down while specific rules stay local, and agents accumulate context by traversing parent directories."
+slots:
+  pattern_id: "## Pattern ID"
+  quick_summary: "## Quick Summary"
+  when_to_use: "## When To Use"
+  core_mechanism: "## Core Mechanism"
+  key_rules: "## Key Rules"
+  implementation_notes: "## Implementation Notes"
+  failure_modes: "## Failure Modes"
+  signals_diagnostics: "## Signals & Diagnostics"
+  tradeoffs: "## Tradeoffs"
+  related_patterns: "## Related Patterns"
+  source_anchors: "## Source Anchors"
+---
+
+## Pattern ID
+
+hierarchical-persistent-memory
+
+## Quick Summary
+
+AGENTS.md is not one file -- it is a hierarchy. Rules at the root apply globally. Rules at the component level are specific. When an agent traverses the file system, it picks up rules from parent directories. This creates layered context where general project rules coexist with component-specific patterns. AGENTS.md serves three functions: rules (coding style, standards, project setup), skills (what the agent can do, tool knowledge), and memory (learnings from past runs, what to do and what not to do).
+
+## When To Use
+
+- Multi-component projects where each component has distinct patterns or requirements
+- When global project rules need to coexist with module-specific guidance
+- Projects shared between multiple AI coding tools (Claude Code, Codex) where AGENTS.md can be referenced from CLAUDE.md or symlinked
+- Long-running projects where past learnings should inform future agent runs
+- Large codebases where loading all context at once would exceed token budgets
+
+## Core Mechanism
+
+AGENTS.md files are placed at multiple directory levels:
+
+**Root level:** Project-wide rules -- coding style, commit conventions, architecture patterns, global don'ts.
+
+**Component level:** Module-specific guidance -- API patterns, framework usage, component-specific testing requirements.
+
+**Tool level:** Per-tool configuration -- how to use specific libraries, integration patterns.
+
+When an agent operates on a file, it traverses upward from that file's directory to the root, collecting AGENTS.md files. Later files in the traversal (closer to root) provide broader context, while earlier files (closer to the working directory) provide specific guidance. This creates a layered context stack where specific rules override or augment general rules.
+
+Progressive disclosure: the main AGENTS.md file is always loaded (target ~2,000 tokens). References or sub-files are loaded only when relevant flags, modes, or tools are detected, keeping default token cost low.
+
+Cross-agent sharing: AGENTS.md can be referenced from CLAUDE.md, or symlinked to the same file when running Claude Code and Codex in parallel on the same project.
+
+## Key Rules
+
+1. AGENTS.md files must never contradict each other -- component-level files augment root files, they don't override fundamental project standards.
+2. Root AGENTS.md should contain only universal project rules -- if a rule applies to one component but not others, it belongs in the component directory.
+3. Keep main AGENTS.md files under 2,000 tokens -- use references or sub-files for detailed documentation that should load conditionally.
+4. AGENTS.md is for rules, skills, and memory -- not general project documentation or API reference (those belong in docs/).
+5. Update AGENTS.md as learnings accumulate -- if an agent makes the same mistake twice, add a rule to prevent the third occurrence.
+6. When symlinking or referencing AGENTS.md from CLAUDE.md, ensure the reference path is absolute or correctly relative to avoid breakage.
+
+## Implementation Notes
+
+Establish a three-layer hierarchy as a starting template:
+
+1. **Protocol file (root):** Project-wide rules, commit conventions, architecture patterns.
+2. **Focused persona/skill files (component level):** Module-specific guidance, framework patterns, testing requirements.
+3. **Maintenance subagent (optional):** A dedicated agent or script that updates AGENTS.md files based on learnings from previous runs.
+
+Use symbolic links when running multiple AI tools on the same project to avoid duplicating AGENTS.md content.
+
+Consider splitting large AGENTS.md files into a main file plus a `references/` subdirectory, where the main file is always loaded and references are loaded conditionally based on flags, modes, or tool detection.
+
+Emergent Mind analysis shows that AGENTS.md files have a median size of ~336 words (~142 lines) and tend to have a shallow hierarchy -- most projects use 2-3 levels, not 5+.
+
+## Failure Modes
+
+- **Contradictory rules:** Component-level AGENTS.md forbids a pattern that root AGENTS.md requires. Agent behavior becomes unpredictable.
+- **Rule bloat:** Root AGENTS.md accumulates component-specific rules over time, inflating token cost for all agents even when rules are irrelevant.
+- **Stale memory:** AGENTS.md contains outdated rules from a previous project phase. Agents follow obsolete guidance.
+- **Broken references:** CLAUDE.md references AGENTS.md using a relative path that breaks when the working directory changes.
+- **Over-documentation:** AGENTS.md becomes a knowledge base dump instead of a focused set of rules and learnings. Token budget wasted on irrelevant context.
+- **No traversal support:** Agent implementation reads only the root AGENTS.md, missing component-level context.
+
+## Signals & Diagnostics
+
+- **Pattern is needed:** Agents repeatedly make the same mistakes in specific components despite general project rules. Agents waste tokens searching for configuration or framework patterns that could be documented.
+- **Pattern is working:** Agents automatically apply component-specific patterns when working in those components. Token usage remains stable as project grows because only relevant context is loaded. Learnings from past runs prevent repeated mistakes.
+- **Pattern is failing:** Agents ignore component-level AGENTS.md files. Token usage grows linearly with project size because all context is always loaded. Agents make the same mistakes repeatedly despite AGENTS.md rules.
+
+## Tradeoffs
+
+**Gain:** Agents accumulate durable context across sessions. General rules apply broadly while specific rules stay local. Token cost remains bounded even as project complexity grows. Learnings compound over time instead of being lost between sessions.
+
+**Cost:** AGENTS.md maintenance becomes an ongoing task -- files must be updated as patterns evolve. Traversal logic adds complexity to agent implementation. Risk of contradictory rules if hierarchy is not carefully managed. Initial setup cost to establish the hierarchy and decide what belongs at each level.
+
+## Related Patterns
+
+- **Spec as Source of Truth** -- AGENTS.md encodes validated patterns from completed tasks
+- **Hydration Pattern** -- AGENTS.md provides baseline context for agents before they start work
+- **Skill Bootstrapping** -- AGENTS.md documents skills available to agents
+- **Meta-Prompting** -- AGENTS.md can contain prompts or prompt fragments for specific scenarios
+
+## Source Anchors
+
+- [From Prompts to AGENTS.md: What Survives Across Thousands of Runs](https://www.youtube.com/watch?v=aMwuPa6BnaM) -- AI Native Dev NYC talk by Tessl
+- [Tessl blog post: From Prompts to AGENTS.md](https://tessl.io/blog/from-prompts-to-agents-md-what-survives-across-thousands-of-runs/)
+- [Support AGENTS.md -- Issue #6235 -- anthropics/claude-code](https://github.com/anthropics/claude-code/issues/6235) (2,838+ upvotes)
+- [Pointing CLAUDE.md to AGENTS.md](https://www.reddit.com/r/ClaudeCode/comments/1r9zx34/pointing_claudemd_to_agentsmd/) (34 pts, 53 comments) -- r/ClaudeCode
+- [AGENTS.md Files: AI Agent Configuration -- Emergent Mind](https://www.emergentmind.com/topics/agents-md-files) -- median file ~336 words, ~142 lines, consistent shallow hierarchy
+- [Stop Using /init for AGENTS.md -- Addy Osmani](https://addyosmani.com/blog/agents-md/) -- three-layer hierarchy: protocol file, focused persona/skill files, maintenance subagent
+- [Complete Guide to Skills.md in 2026](https://www.flex.com.ph/articles/complete-guide-to-skillsmd-in-2026) -- Skills.md as complementary convention

--- a/.claude/references/proposed-patterns/pattern-lifecycle-memory-checkpoints.md
+++ b/.claude/references/proposed-patterns/pattern-lifecycle-memory-checkpoints.md
@@ -2,6 +2,7 @@
 slug: lifecycle-memory-checkpoints
 display_name: "Lifecycle Memory Checkpoints"
 one_liner: "Four write mechanisms fired at specific moments in a conversation's lifecycle -- bootstrap load, pre-compaction flush, session snapshot, user-initiated save -- that turn inert markdown files into persistent agent memory."
+intel_date: 2026-02-26
 slots:
   pattern_id: "## Pattern ID"
   quick_summary: "## Quick Summary"

--- a/.claude/references/proposed-patterns/pattern-lifecycle-memory-checkpoints.md
+++ b/.claude/references/proposed-patterns/pattern-lifecycle-memory-checkpoints.md
@@ -1,0 +1,329 @@
+---
+slug: lifecycle-memory-checkpoints
+display_name: "Lifecycle Memory Checkpoints"
+one_liner: "Four write mechanisms fired at specific moments in a conversation's lifecycle -- bootstrap load, pre-compaction flush, session snapshot, user-initiated save -- that turn inert markdown files into persistent agent memory."
+slots:
+  pattern_id: "## Pattern ID"
+  quick_summary: "## Quick Summary"
+  when_to_use: "## When To Use"
+  core_mechanism: "## Core Mechanism"
+  key_rules: "## Key Rules"
+  implementation_notes: "## Implementation Notes"
+  failure_modes: "## Failure Modes"
+  signals_diagnostics: "## Signals & Diagnostics"
+  tradeoffs: "## Tradeoffs"
+  related_patterns: "## Related Patterns"
+  source_anchors: "## Source Anchors"
+---
+
+## Pattern ID
+
+lifecycle-memory-checkpoints
+
+## Quick Summary
+
+AI agents are stateless -- every conversation starts blank. Memory files (markdown, SQLite, etc.) can persist knowledge across sessions, but files alone are inert. What makes memory work is not where you store it but **when you read and write it**. This pattern defines four lifecycle mechanisms that fire at specific moments in a conversation to checkpoint agent state:
+
+1. **Bootstrap loading** -- inject durable memory at session start so the agent has instant recall
+2. **Pre-compaction flush** -- before lossy context compression, silently prompt the agent to save anything important to disk (the write-ahead log pattern from databases)
+3. **Session snapshot** -- on explicit session reset, capture raw conversation text as a recoverable checkpoint
+4. **User-initiated save** -- "remember this" triggers agent-categorized write to the appropriate memory tier
+
+These mechanisms operate on a two-tier markdown storage model that the community has converged on: a curated semantic memory file (MEMORY.md, 200-line cap, always loaded) and append-only episodic daily logs (memory/YYYY-MM-DD.md, today + yesterday loaded). The pattern extends to team-scoped institutional memory in enterprise contexts where agents pick up Jira tickets and accumulate project knowledge that benefits the whole team.
+
+Google's memory taxonomy (November 2025 whitepaper) provides the conceptual framework: **episodic** (what happened), **semantic** (stable facts and preferences), and **procedural** (workflows and learned routines). The four mechanisms are the engineering that makes this taxonomy operational.
+
+## When To Use
+
+- Agents that need cross-session continuity without vector databases or external infrastructure
+- Local-first coding agents where markdown files are the natural storage medium
+- Long-running sessions where context window compaction would silently destroy important information
+- Enterprise engineering workflows where agents accumulate institutional knowledge (blockers, architectural decisions, team conventions, past incident context) across Jira tickets and PRs
+- Multi-agent systems where one agent's learnings should be available to future agents working on the same project
+- Any system where you observe agents "forgetting" decisions made in previous sessions or earlier in long conversations
+
+## Core Mechanism
+
+### The Memory Taxonomy
+
+Three types of memory, following Google's framework:
+
+| Type | What It Stores | Example | Storage |
+|------|---------------|---------|---------|
+| **Semantic** | Stable facts, preferences, identity | "This repo uses Biome not ESLint" | MEMORY.md (curated, capped) |
+| **Episodic** | What happened in past interactions | "Hit a race condition in payments service -- see PR #4231" | Daily logs + session snapshots |
+| **Procedural** | Workflows and learned routines | "Always run migrations before seeding in this project" | MEMORY.md or skill files |
+
+### The Two-Tier Storage Model
+
+**Tier 1: MEMORY.md (semantic memory)**
+- Curated long-term memory with a 200-line cap
+- Structured sections (identity, preferences, project conventions, known issues)
+- Loaded into every prompt automatically -- zero retrieval latency
+- Agent and human can both write to it
+
+**Tier 2: Daily logs (episodic memory)**
+- `memory/YYYY-MM-DD.md` -- one file per day, append-only
+- Today and yesterday's logs loaded at session start (recent context window)
+- Older logs available via search on demand (cold storage)
+- Never edited, only appended -- preserves full history
+
+**Tier 3 (optional): Session snapshots**
+- Raw conversation fragments saved on explicit session reset
+- Not summaries -- actual message text (last 15 meaningful messages)
+- LLM generates a descriptive filename slug (e.g., `2026-02-08-api-design.md`)
+- Searchable but not auto-loaded
+
+### The Four Mechanisms
+
+**Mechanism 1: Bootstrap Loading (session start)**
+
+On every new conversation, the system injects MEMORY.md into the prompt. The agent always has it -- no decision required, no file read needed. On top of that, the agent's instructions tell it to read today and yesterday's daily logs for recent episodic context. This is the simplest and most important mechanism.
+
+```
+Session starts ->
+  System injects MEMORY.md (automatic)
+  Agent reads today's daily log (per its own instructions)
+  Agent reads yesterday's daily log (per its own instructions)
+  Agent has full semantic + recent episodic context
+```
+
+**Mechanism 2: Pre-Compaction Flush (approaching context limit)**
+
+When the session nears the context window limit, a silent agentic turn is injected -- invisible to the user. It instructs the agent to save anything important to the daily log before lossy LLM summarization (compaction) proceeds. This turns a destructive operation into a checkpoint.
+
+```
+Context nears limit ->
+  System injects silent turn: "Pre-compaction memory flush.
+    Store durable memories now (use memory/YYYY-MM-DD.md).
+    If nothing to store, reply with NO_REPLY."
+  Agent writes important context to daily log
+  Agent replies NO_REPLY (invisible to user)
+  Compaction proceeds -- context is lossy-compressed
+  Important information already safe on disk
+```
+
+This is the **write-ahead log pattern from databases** applied to agent memory. Multiple independent sources converge on this name and mechanism.
+
+**Mechanism 3: Session Snapshot (explicit reset)**
+
+When the user starts a new session (`/new`, `/reset`), a hook captures the last chunk of conversation. The snapshot is raw message text, not a generated summary -- preserving the exact exchanges. An LLM generates a descriptive filename slug. The snapshot is searchable in future sessions.
+
+```
+User runs /new ->
+  Hook extracts last 15 meaningful messages
+  Filters out tool calls, system messages, slash commands
+  LLM generates descriptive slug
+  Saved as memory/YYYY-MM-DD-<slug>.md
+  New session starts with clean context + bootstrap loading
+```
+
+**Mechanism 4: User-Initiated Save**
+
+The simplest mechanism -- the user says "remember this" and the agent decides where it belongs:
+- Stable fact or preference -> MEMORY.md (semantic)
+- Event or decision from current work -> daily log (episodic)
+- Workflow or routine -> MEMORY.md procedural section or skill file
+
+No special hook needed. The agent has file-writing capabilities and its instructions tell it how to route information.
+
+### Memory Scopes for Enterprise
+
+In team engineering contexts, memory needs multiple scopes:
+
+| Scope | Location | Visibility | Example |
+|-------|----------|------------|---------|
+| **Personal** | `~/.claude/agent-memory/` | Private to user | "I prefer tabs and dark mode" |
+| **Project** | `.claude/agent-memory/` | Git-tracked, team-shared | "This repo has a known Stripe webhook race condition" |
+| **Institutional** | Project daily logs | Team-shared | "Sarah from platform said auth middleware deprecated in Q3" |
+| **Episodic work log** | `memory/YYYY-MM-DD.md` | Per-agent or shared | "Picked up PROJ-123, hit blocker on Redis connection pooling" |
+
+The pre-compaction flush and session snapshots become more valuable in enterprise contexts -- you're not just saving "what I was working on" but "what the team's agent learned while working on it." An agent picking up PROJ-456 next week benefits from the daily log entry that recorded the blocker on PROJ-123.
+
+### Memory Consolidation
+
+Storage is the easy part. The hard problems are extraction and consolidation:
+
+**Extraction** -- deciding what's worth remembering. Not every detail of a conversation is important. The community heuristic: "If the agent would make a different decision with vs without this piece of info, store it."
+
+**Consolidation** -- deduplicating and updating entries over time. Example: user says "I prefer dark mode" in one session, "I don't like dark mode anymore" in another, "I switched back to dark mode" in a third. Without consolidation, all three entries sit in memory. A good memory system collapses them into: "User prefers dark mode (as of 2026-02-26)."
+
+**Overwrite capability** -- something true today may not be true tomorrow. The memory system must differentiate and update its knowledge bank. Without this, memory becomes noisy and contradictory.
+
+These operations are typically handled by a separate LLM call that takes conversation context and handles extraction/consolidation. Some implementations use nightly distillation (OpenCortex) or weekly cron-based archival.
+
+## Key Rules
+
+1. **MEMORY.md is always loaded, never searched** -- it is the hot tier. If it needs a retrieval step, it's too big or too poorly organized.
+2. **Daily logs are append-only** -- never edit or delete entries. Consolidation happens by promoting durable facts to MEMORY.md, not by modifying the log.
+3. **Pre-compaction flush fires exactly once per compaction cycle** -- tracked in session state. Multiple flushes waste tokens.
+4. **Session snapshots are raw text, not summaries** -- summaries are lossy. Raw conversation preserves the exact context for future search.
+5. **The 200-line cap on MEMORY.md is a hard constraint** -- exceeding it bloats every prompt. Use topic-specific overflow files for depth.
+6. **Memory consolidation requires a separate LLM call** -- do not ask the in-conversation agent to also manage memory consolidation. Separation of concerns.
+7. **Enterprise memory scopes are explicit** -- personal memory stays personal, project memory is git-tracked. Mixing scopes leaks preferences into team context or team decisions into private memory.
+8. **Silent turns must be truly invisible** -- the pre-compaction flush must not appear in the user's conversation. If the user sees "Pre-compaction memory flush," the implementation is broken.
+
+## Implementation Notes
+
+**OpenClaw's pre-compaction flush config (production reference):**
+
+```json
+{
+  "agents": {
+    "defaults": {
+      "compaction": {
+        "reserveTokensFloor": 20000,
+        "memoryFlush": {
+          "enabled": true,
+          "softThresholdTokens": 4000,
+          "systemPrompt": "Session nearing compaction. Store durable memories now.",
+          "prompt": "Write any lasting notes to memory/YYYY-MM-DD.md; reply with NO_REPLY if nothing to store."
+        }
+      }
+    }
+  }
+}
+```
+
+Flush triggers when `contextWindow - reserveTokensFloor - softThresholdTokens` is crossed.
+
+**Claude Code PreCompact hook (community pattern):**
+
+The PreCompact hook spawns a separate Claude instance via `claude -p` to summarize the full conversation, saves it as `HANDOVER-YYYY-MM-DD.md`, then compaction proceeds. An advanced variant from the Anthropic cookbook uses background threads: at a soft token threshold, a background worker starts building a session memory summary. When the hard limit hits, the swap is instant -- zero user wait.
+
+The `SESSION_MEMORY_PROMPT` schema that drives the summary explicitly preserves:
+- User corrections (verbatim)
+- Errors and failed approaches (to prevent retries)
+- Exact file paths and IDs
+- Active task state
+
+**Claude Code native agent memory (v2.1.33, February 2026):**
+
+Three scopes: `user` (~/.claude/agent-memory/, private), `project` (.claude/agent-memory/, team-shareable via git), `local` (.claude/agent-memory-local/, personal project). Each agent gets its own MEMORY.md. First 200 lines injected at startup, topic-specific overflow files created autonomously. Key distinction: CLAUDE.md is human-written and read by all agents; agent memory is agent-written and read only by that specific agent.
+
+**ianlpaterson's 4-layer architecture (community reference):**
+
+1. Always-loaded MEMORY.md with routing table (capped at 200 lines)
+2. Per-project CLAUDE.md with embedded `## State` sections
+3. Daily logs at `~/llm-data/daily-log/` for episodic capture
+4. On-demand topic files for depth
+
+`/flush` command at session end appends to daily logs and promotes repeated lessons from episodic to semantic. Weekly cron archives stale MEMORY.md entries. Six validation scripts enforce 8 design rules.
+
+**Hybrid retrieval (for teams outgrowing pure markdown):**
+
+OpenClaw's search layer indexes markdown files into SQLite with the sqlite-vec extension:
+- Chunks at ~400 tokens with 80-token overlap
+- BM25 + vector hybrid (70/30 split), score threshold 0.35
+- MMR re-ranking (lambda 0.7) to prevent near-duplicate daily notes from dominating
+- Temporal decay: `decayedScore = score * e^(-lambda * ageInDays)` with 30-day half-life
+- Evergreen files (MEMORY.md, non-dated files) never decayed
+- No external vector DB -- SQLite is the entire backend
+
+**The desk and filing cabinet analogy:**
+
+The session is a messy desk -- notes and documents scattered for the current project. Memory is the filing cabinet -- categorized, stored, retrievable. The four mechanisms are the habits that move things from desk to cabinet at the right moments. Without the habits, the filing cabinet stays empty no matter how well-organized it is.
+
+## Failure Modes
+
+- **No pre-compaction flush:** Context is silently compressed. Important decisions, file paths, and error context are lost. The agent "forgets" mid-session and the user has to re-explain the codebase. This is the single most common complaint in the community (256-pt r/ClaudeCode thread; @yashns1 viral X post).
+- **No consolidation:** Three contradictory entries about the same preference sit in memory. The agent picks one arbitrarily or tries to reconcile all three, producing inconsistent behavior. Memory becomes noisy over time.
+- **MEMORY.md exceeds cap:** Every prompt pays the full token cost of bloated memory. Attention dilutes across irrelevant entries. Agent performance degrades on all tasks, not just memory-related ones.
+- **Summaries instead of snapshots:** Session snapshots are LLM-generated summaries instead of raw conversation text. The summary omits the exact detail needed for future retrieval. Garbage in, garbage out.
+- **No memory scoping in enterprise:** Personal preferences leak into team memory. An agent's MEMORY.md contains "Nathan prefers tabs" alongside "the payments service has a webhook race condition." Other team members' agents inherit irrelevant personal preferences.
+- **Creation memory gap:** Agent creates a file, function, or configuration, then forgets it exists in a later session. Memory captures what was discussed but not what was produced. The agent duplicates work or creates conflicting implementations.
+- **Bootstrap overload:** Too much memory loaded at session start. Agent spends its context budget on historical memory instead of the current task. The "more context does not mean better agents" finding from the ACC paper applies here.
+- **Stale memory without decay:** A fact that was true six months ago remains in MEMORY.md unchallenged. The agent follows obsolete guidance. Without temporal decay or explicit review cycles, memory accumulates entropy.
+
+## Signals & Diagnostics
+
+- **Pattern is needed:** Agents lose context mid-session after compaction. Users re-explain the same project setup every new session. Agents repeat mistakes that were solved in previous sessions. Enterprise agents pick up Jira tickets with no context about past blockers or decisions.
+- **Pattern is working:** Agents have instant recall of project conventions at session start. Pre-compaction flushes capture important decisions before context is compressed. Session snapshots enable recovery of exact conversation context. Enterprise agents reference past incident context when encountering similar problems.
+- **Pattern is failing:** MEMORY.md grows past 200 lines and attention dilutes. Pre-compaction flush fires but the agent writes nothing useful (extraction quality problem). Daily logs accumulate noise without consolidation. Team memory contains personal preferences. Agents still "forget" after compaction despite the flush mechanism.
+
+## Tradeoffs
+
+**Gain:** Agents maintain continuity across sessions without external infrastructure. The pre-compaction flush transforms a destructive operation (lossy compression) into a checkpoint (write-ahead log). Enterprise teams accumulate institutional knowledge that compounds across agents and sessions. Markdown storage is readable, debuggable, portable, and git-trackable.
+
+**Cost:** Four mechanisms means four potential failure points. Memory consolidation requires additional LLM calls (token cost). The 200-line MEMORY.md cap forces hard decisions about what's worth remembering. Daily logs grow unbounded without archival. Enterprise memory scoping adds organizational complexity. The community is split on when plain markdown stops being sufficient and hybrid retrieval (vector search) becomes necessary -- there is no clear threshold, and premature optimization toward vector DBs adds infrastructure cost for marginal benefit on small corpora.
+
+**The live debate:** In-context memory (MEMORY.md loaded into every prompt) is simple and reliable but vulnerable to compaction. External memory (Mem0-style, outside the context window) survives compaction but adds infrastructure and retrieval latency. The pragmatic middle ground: MEMORY.md for the hot tier (always loaded, small), daily logs for the warm tier (loaded on demand), and vector-indexed cold storage only when the corpus outgrows filesystem search. LlamaIndex benchmarks (January 2026) show filesystem retrieval outperforms vector RAG on small corpora, supporting the "start simple" approach.
+
+## Related Patterns
+
+- **Hierarchical Persistent Memory** -- complementary pattern. Hierarchical Persistent Memory defines *where* to place memory files (root, component, tool directories). Lifecycle Memory Checkpoints defines *when* to read and write them. A memory system needs both: hierarchy for organization, lifecycle hooks for operation.
+- **Context Engineering** -- the parent discipline. Context Engineering manages context window quality through controlled handoffs, context surgery, and spec-file re-reads. Lifecycle Memory Checkpoints is a specific implementation of context engineering focused on the memory lifecycle. The pre-compaction flush is a form of controlled handoff (disk checkpoint before lossy compression). Wave-boundary spec re-reads are the orchestration equivalent of bootstrap loading.
+- **Hydration Pattern** -- bootstrap loading is hydration applied to memory. The Hydration Pattern serializes orchestration state into a spec file for cross-session resume. Bootstrap loading serializes agent memory into MEMORY.md for cross-session recall. Same mechanism, different payload.
+- **Spec as Source of Truth** -- the spec file is re-read from disk at wave boundaries for the same reason MEMORY.md is loaded at session start: critical information should not depend on context window survival. Both patterns defend against compaction by keeping the source of truth on disk.
+- **Prompt Hop Chain Reduction** -- memory instructions ("read today's daily log") are hop chains. If the agent skips the read, it loses recent episodic context. Bootstrap loading of MEMORY.md avoids this by system-injecting it (zero hops). Daily log loading remains agent-directed (one hop) and is therefore subject to skip-read failure.
+- **Skill Bootstrapping** -- MEMORY.md can contain procedural memory (workflows, learned routines) that functions as bootstrapped skill knowledge. The distinction: skills are static (written once, loaded always), while memory is dynamic (written by the agent, evolving over time). The two compound when an agent's learned routines graduate from episodic daily log entries into stable MEMORY.md procedures.
+- **Self-Reflecting Analytics** -- the extraction and consolidation step in memory is a form of self-reflection. The agent (or a separate LLM call) analyzes its own session to determine what's worth remembering. Self-Reflecting Analytics applies the same introspection to execution metrics; Lifecycle Memory Checkpoints applies it to knowledge persistence.
+- **Meta-Prompting** -- nightly distillation and weekly archival of memory are meta-operations on the memory system itself. A maintenance subagent that consolidates daily logs into MEMORY.md entries is meta-prompting applied to memory management.
+- **Three-Layer Influence Model** -- MEMORY.md sits in the durable middle layer (survives across sessions, unlike volatile user prompts; more adaptable than system prompts). The three-layer model explains why investing in MEMORY.md quality has outsized returns compared to prompt engineering or system prompt tuning.
+- **Community Pattern Mining** -- community-mined AGENTS.md patterns can seed an agent's initial MEMORY.md with project conventions discovered from thousands of repos, providing a cold-start bootstrap before the agent has generated any of its own memories.
+
+## Source Anchors
+
+### Primary Sources
+
+- [How AI Agents Remember Things](https://www.youtube.com/watch?v=Seu7nksZ_4k) (51,280 views, 2,310 likes) -- Damian Galarza; the four-mechanism framework (bootstrap loading, pre-compaction flush, session snapshot, user-initiated save) with OpenClaw as reference implementation
+- [How AI Agents Remember Things (blog post)](https://www.damiangalarza.com/posts/2026-02-17-how-ai-agents-remember-things/) -- Damian Galarza; written companion to the video with deeper technical detail
+- [How Clawdbot Remembers Everything](https://manthanguptaa.in/posts/clawdbot_memory/) -- manthanguptaa.in; most technically precise public writeup on pre-compaction flush, includes YAML config, hybrid search architecture (BM25 + vector 70/30), cache-TTL pruning
+- [Effective context engineering for AI agents](https://www.anthropic.com/engineering/effective-context-engineering-for-ai-agents) -- Anthropic Engineering; compaction strategies, structured note-taking, sub-agent architectures, just-in-time context
+- [Context Engineering: Sessions and Memory (whitepaper)](https://www.kaggle.com/whitepaper-context-engineering-sessions-and-memory) -- Google (Kimberly Milam, Antonio Gulli); the episodic/semantic/procedural taxonomy, 72-page treatment of memory generation, extraction, consolidation
+- [OpenClaw memory.md source doc](https://github.com/openclaw/openclaw/blob/main/docs/concepts/memory.md) -- 736 lines of production implementation detail; pre-compaction flush config, MMR re-ranking formula, temporal decay math, hybrid search architecture
+- [Manage Claude's memory -- Claude Code Docs](https://code.claude.com/docs/en/memory) -- official Claude Code native agent memory (v2.1.33); three scopes (user, project, local), 200-line injection, agent-written memory distinct from human-written CLAUDE.md
+
+### Community Implementations
+
+- [Claude Code Memory Architecture -- 4-layer autonomous system](https://ianlpaterson.com/blog/claude-code-memory-architecture/) -- ianlpaterson; MEMORY.md routing table + daily logs + topic files + weekly cron archival + 6 validation scripts
+- [Claude Code Auto Memory & PreCompact Hooks Explained](https://yuanchang.org/en/posts/claude-code-auto-memory-and-hooks/) -- yuanchang.org; PreCompact hook spawning `claude -p` for HANDOVER files
+- [Anthropic Session Memory Compaction Cookbook](https://platform.claude.com/cookbook/misc-session-memory-compaction) -- instant compaction via background threads, SESSION_MEMORY_PROMPT schema
+- [We Built Persistent Memory for OpenClaw (Mem0)](https://mem0.ai/blog/mem0-memory-for-openclaw) -- mem0.ai; external memory argument (MEMORY.md vulnerable to compaction), auto-recall/auto-capture, self-hosted option
+- [Claude-Mem](https://github.com/thedotmack/claude-mem) (12.9K GitHub stars) -- 3-layer retrieval (compact index -> timeline context -> full observations), SQLite storage, Claude Agent SDK compression
+- [Claude-Mem docs](https://docs.claude-mem.ai/introduction) -- architecture and configuration reference
+- [Persistent Memory in Claude Code with claude-mem](https://betterstack.com/community/guides/ai/claude-mem/) -- Better Stack setup guide
+
+### Community Discussion (Reddit)
+
+- [Please stop creating "memory for your agent" frameworks](https://www.reddit.com/r/ClaudeCode/comments/1r4asf6/) (256 pts, 132 comments) -- r/ClaudeCode; community fatigue at proliferation; MEMORY.md + sub-files "works wonderfully"
+- [PSA: Turn on memory search with embeddings](https://www.reddit.com/r/openclaw/comments/1r5mgmu/) (94 pts, 38 comments) -- r/openclaw; tiered memory (core under 4K chars always loaded, cold storage via embedding search)
+- [AI agents need better memory systems, not just bigger context windows](https://www.reddit.com/r/AI_Agents/comments/1r0q4qf/) (76 pts, 31 comments) -- r/AI_Agents; "a markdown file the agent reads at start and writes at end -- Claude Code already does this with CLAUDE.md"
+- [I Spent 5 Days Fixing My AI Agent's Memory](https://www.reddit.com/r/AskClaw/comments/1rci23e/) (65 pts, 17 comments) -- r/AskClaw; "write discipline, pre-compaction flush, boot sequence, handover protocol -- should ship as default infrastructure"
+- [We built a memory backend for OpenClaw agents (.h5 file)](https://www.reddit.com/r/openclaw/comments/1rcopg2/) (62 pts, 51 comments) -- r/openclaw; "380us at 100k memories"; top comment: "There is now 1,000 different memory solutions"
+- [I gave an AI agent persistent memory using just markdown files](https://www.reddit.com/r/ChatGPT/comments/1qx37t7/) (30 pts, 45 comments) -- r/ChatGPT; two-tier approach (daily logs + periodic distillation into MEMORY.md)
+- [We built persistent memory for OpenClaw (Mem0)](https://www.reddit.com/r/openclaw/comments/1regq4c/) (26 pts, 21 comments) -- r/openclaw; debate over whether compaction preserves MEMORY.md
+- [OpenCortex: A self-improving memory system](https://www.reddit.com/r/openclaw/comments/1rdzewv/) (24 pts, 12 comments) -- r/openclaw; nightly distillation into structured buckets
+- [AI agents have a creation memory problem](https://www.reddit.com/r/AIMemory/comments/1rdffhk/) (9 pts, 12 comments) -- r/AIMemory; agents forget what they created, distinct from conversation memory
+- [I built an open-source memory layer for Claude Code (Engram)](https://www.reddit.com/r/claude/comments/1rcrbqa/) (11 pts, 27 comments) -- r/claude
+
+### Community Discussion (X)
+
+- [Claude-Mem viral announcement](https://x.com/hasantoxr/status/2017989926428778985) (10,465 likes, 1,054 reposts) -- @hasantoxr; "95% fewer tokens, 20x more tool calls"
+- [Memory is a prediction problem, not a retrieval problem](https://x.com/helloiamleonie/status/2017370424808509451) (1,144 likes) -- @helloiamleonie; conceptual challenge to RAG-based memory
+- [Anthropic context engineering playbook open-sourced](https://x.com/ihtesham2005/status/2026210386740216161) (981 likes, 116 reposts) -- @ihtesham2005
+- [Agentic file system paper](https://x.com/rohanpaul_ai/status/2008445933424386074) (1,672 likes, 223 reposts) -- @rohanpaul_ai
+- [AgeMem -- unified long/short-term memory framework](https://x.com/omarsar0/status/2010712137933730234) (635 likes, 111 reposts) -- @omarsar0
+- [Agent Cognitive Compressor (ACC) paper](https://x.com/dair_ai/status/2014000799245107339) (375 likes, 76 reposts) -- @dair_ai; "more context does not mean better agents"
+- [CLAUDE.md-as-memory pattern](https://x.com/jason_haugh/status/2026024989254619251) -- @jason_haugh; "agent rewrites its own operating instructions as it learns"
+- [Markdown-file memory skepticism](https://x.com/tulipking/status/2024691063177318779) (29 likes) -- @tulipking; "not convinced the solution is a more opinionated structure of md files"
+
+### YouTube
+
+- [How AI Agents Remember Things](https://www.youtube.com/watch?v=Seu7nksZ_4k) (51,280 views) -- Damian Galarza
+- [How AI Agents Search Their Memory (Part 2)](https://www.youtube.com/watch?v=SpReZZk_13w) -- Damian Galarza
+- [Claude Code With UNLIMITED Memory!](https://www.youtube.com/watch?v=qhuS__jC4n8) (33,735 views) -- WorldofAI
+- [Context Engineering Our Way to Long-Horizon Agents](https://www.youtube.com/watch?v=vtugjs2chdA) (109,285 views) -- Harrison Chase / Sequoia Capital
+- [Give Claude Persistent Memory in 5 Minutes](https://www.youtube.com/watch?v=ryqpGVWRQxA) (19,441 views) -- Better Stack
+- [Self Improving Subagents with Memory](https://www.youtube.com/watch?v=KoS7w--Cu94) (2,500 views) -- Jaymin West
+
+### Academic
+
+- [Agent Cognitive Compressor (ACC)](https://x.com/dair_ai/status/2014000799245107339) -- bio-inspired memory controller for bounded persistent memory; challenges the "more context = better" assumption
+- [AriadneMem -- scalable memory for lifelong agents](https://x.com/WenhuiZhu8/status/2020628416119349612) (205 likes, 416 reposts) -- graph traversal approach to long-term agent memory
+- [Evaluating AGENTS.md: Are Repository-Level Context Files Helpful for Coding Agents?](https://arxiv.org/abs/2602.11988) -- ETH Zurich; context file redundancy as a form of context pollution
+
+### Related Issues
+
+- [Support AGENTS.md -- anthropics/claude-code #6235](https://github.com/anthropics/claude-code/issues/6235) (2,838+ upvotes) -- the upstream feature request driving community memory patterns
+- [Indexed transcript references in compaction summaries -- #26771](https://github.com/anthropics/claude-code/issues/26771) -- feature request for compaction to preserve indexed references to original transcript turns

--- a/.claude/references/proposed-patterns/pattern-meta-prompting.md
+++ b/.claude/references/proposed-patterns/pattern-meta-prompting.md
@@ -1,0 +1,161 @@
+---
+slug: meta-prompting
+display_name: "Meta-Prompting"
+one_liner: "After a completed orchestration, a reflection agent analyzes the execution trace and proposes rule improvements that compound the orchestrator's effectiveness across runs -- with mandatory human approval before any change is applied."
+slots:
+  pattern_id: "## Pattern ID"
+  quick_summary: "## Quick Summary"
+  when_to_use: "## When To Use"
+  core_mechanism: "## Core Mechanism"
+  key_rules: "## Key Rules"
+  implementation_notes: "## Implementation Notes"
+  failure_modes: "## Failure Modes"
+  signals_diagnostics: "## Signals & Diagnostics"
+  tradeoffs: "## Tradeoffs"
+  related_patterns: "## Related Patterns"
+  source_anchors: "## Source Anchors"
+---
+
+## Pattern ID
+
+meta-prompting
+
+## Quick Summary
+
+Meta-Prompting is a post-orchestration reflection phase where a dedicated agent analyzes the execution trace -- task durations, retry counts, HITL escalations, token usage, validator failure reasons -- and proposes structured improvements to the orchestrator's rules, patterns, and skill file. The proposals are always presented to the user for approval. No change is auto-applied. Approved proposals are stored in a `learnings/` directory alongside the spec file for retrieval in future runs. Over time, the orchestrator compounds its effectiveness: recurring failure modes get rules that prevent them, successful patterns get reinforced, and token-wasting behaviors get eliminated.
+
+## When To Use
+
+- After a completed orchestration run (all tasks `VERDICT: PASS` or explicitly skipped via HITL)
+- After a failed orchestration where the failure pattern is instructive (repeated retries on the same failure mode, systematic validator rejections)
+- When the orchestrator has accumulated 3+ completed runs and cross-run patterns should be surfaced
+- When the user passes `--reflect` to explicitly request post-run analysis
+- When HITL escalations occurred during the run -- these are signals of orchestrator limitations worth learning from
+
+## Core Mechanism
+
+Meta-Prompting runs as an optional post-orchestration phase triggered by `orchestration.complete` or `--reflect`:
+
+**Step 1: Trace Collection**
+The reflection agent reads the execution trace from the spec file's Execution Log and Hydration Checkpoint sections:
+- Per-task metrics: duration, retry count, validator failure reasons, difficulty rating, which builder was used
+- Aggregate metrics: total token usage, total duration, HITL escalation count, retry rate
+- Failure patterns: which tasks failed, why, how many retries before success, what changed between retries
+
+**Step 2: Pattern Analysis**
+The reflection agent identifies recurring patterns across the current run (and optionally across prior runs if a `learnings/` directory exists):
+- Tasks that consistently required 2+ retries -- what do they have in common?
+- Validator failure reasons that repeat -- are acceptance criteria underspecified?
+- HITL escalations -- could the orchestrator have handled these automatically?
+- Token usage outliers -- which tasks consumed disproportionate tokens and why?
+- Difficulty misclassifications -- tasks rated `standard` that required retries, tasks rated `hard` that passed first try
+
+**Step 3: Proposal Generation**
+The reflection agent produces a maximum of 5 structured proposals, each categorized:
+
+```
+## Proposal <N>: <title>
+
+Category: rule-addition | rule-modification | pattern-gap | prompt-improvement | anti-pattern
+Evidence: <specific trace data that motivates this proposal>
+Current behavior: <what the orchestrator does now>
+Proposed change: <concrete, actionable change -- not vague advice>
+Expected impact: <what metric this should improve>
+Applies to: SKILL.md | agents/<name>.md | references/<name>.md | learnings/
+```
+
+**Step 4: Human Approval Gate**
+Proposals are presented to the user one at a time. For each proposal, the user can:
+1. **Approve** -- the proposal is applied (written to the target file or to `learnings/`)
+2. **Modify** -- the user adjusts the proposal, then approves the modified version
+3. **Reject** -- the proposal is discarded with an optional reason
+4. **Defer** -- the proposal is saved to `learnings/pending.md` for future review
+
+**Step 5: Learning Persistence**
+Approved proposals are written to their target location:
+- Rule additions/modifications: written to `learnings/<run-id>.md` as a structured record. The user decides when to promote learnings into SKILL.md or agent definitions.
+- Pattern gaps: written to `learnings/<run-id>.md` with a flag indicating a new pattern file may be warranted.
+- Anti-patterns: written to `learnings/<run-id>.md` for cross-run retrieval.
+
+The `learnings/` directory lives alongside the spec files (e.g., `specs/learnings/`). Future orchestration runs can read this directory to avoid known pitfalls.
+
+## Key Rules
+
+1. Proposals are never auto-applied -- every change requires explicit human approval. This is the non-negotiable safety constraint. Auto-applying meta-prompted changes creates an uncontrolled feedback loop.
+2. Maximum 5 proposals per reflection -- more than 5 creates decision fatigue. The reflection agent prioritizes by expected impact.
+3. Each proposal must cite specific evidence from the execution trace -- no generic advice. "Improve task descriptions" is not a valid proposal. "Task `implement-auth-middleware` failed 3 times because the validator checked for a `verifyToken` export that was not in the task description" is valid.
+4. Proposals never modify the SKILL.md directly -- they are written to `learnings/`. The user promotes learnings to SKILL.md at their discretion. This prevents the orchestration protocol from drifting without explicit human intent.
+5. The reflection agent is read-only with respect to orchestrator infrastructure -- it reads the spec file and execution log but does not modify them.
+6. Cross-run analysis (reading prior `learnings/` entries) is optional and triggered by the `--history` flag alongside `--reflect`.
+
+## Implementation Notes
+
+**Reflection agent definition:** The reflection agent is a distinct agent type with `disallowedTools: [Write, Edit, NotebookEdit]` (same constraint as the validator). It produces proposals as structured text output. The orchestrator (not the reflection agent) writes approved proposals to disk. This prevents the reflection agent from directly modifying any orchestrator files.
+
+**Model selection:** The reflection agent benefits from a capable reasoning model (Sonnet or Opus) because it performs analytical work -- pattern recognition across trace data, root-cause analysis of failures, proposal generation. This is not mechanical validation; Haiku is insufficient.
+
+**Interaction with hydration-pattern:** The execution trace data that meta-prompting analyzes is already persisted in the spec file's Hydration Checkpoint and Execution Log sections. No additional trace infrastructure is needed -- meta-prompting reads what hydration writes.
+
+**Interaction with hitl-protocol:** HITL escalations during the run are high-signal inputs for meta-prompting. Each escalation represents a case where the orchestrator could not proceed autonomously. The reflection agent should prioritize proposals that would prevent future HITL escalations for the same class of problem.
+
+**Learnings directory structure:**
+
+```
+specs/learnings/
+  2026-02-25-rest-api.md       # Learnings from a specific run
+  2026-02-26-auth-refactor.md  # Learnings from another run
+  pending.md                   # Deferred proposals awaiting review
+```
+
+Each file contains structured proposal records with their approval status and the evidence that motivated them.
+
+**Future run retrieval:** At the start of a new orchestration, if a `learnings/` directory exists, the orchestrator reads the most recent 3 learning files and incorporates any approved rules into the current run's context. This is the compounding mechanism -- past learnings inform future runs without modifying the core SKILL.md.
+
+**Event emissions:**
+- `reflection.started` -- meta-prompting phase begins
+- `reflection.proposal` -- each proposal generated (with category and title)
+- `reflection.approved` -- user approves a proposal
+- `reflection.rejected` -- user rejects a proposal
+- `reflection.deferred` -- user defers a proposal
+- `reflection.complete` -- meta-prompting phase ends
+
+## Failure Modes
+
+- **Auto-applied proposals:** If proposals bypass the human approval gate, the orchestrator's rules drift in unpredictable directions. A bad proposal that compounds across runs (e.g., "always use Codex for all tasks") can degrade performance systematically. The approval gate is the safety mechanism.
+- **Generic proposals:** "Improve task descriptions" or "Be more specific" are not actionable. Without evidence-grounded specificity, proposals waste the user's review time. The 5-proposal cap and evidence requirement prevent this.
+- **Reflection agent modifies files directly:** If the reflection agent has Write/Edit tools, it may "helpfully" apply its own proposals. The `disallowedTools` constraint prevents this structurally.
+- **Learnings not retrieved in future runs:** If the orchestrator does not read the `learnings/` directory at startup, approved proposals have no effect. The compounding loop is broken -- the user approved changes that are never used.
+- **Proposal overload across runs:** If every run generates 5 proposals and all are approved, the `learnings/` directory accumulates noise. The 3-file retrieval cap on future runs prevents context bloat. Periodic user review of `learnings/` to promote stable rules into SKILL.md keeps the directory lean.
+- **Contradictory proposals across runs:** Run A proposes "always use Codex for algorithmic tasks." Run B proposes "never use Codex for algorithmic tasks." Without cross-run consistency checking, both get approved. The user must resolve contradictions during review -- the reflection agent flags potential conflicts when reading prior learnings.
+
+## Signals & Diagnostics
+
+- **Pattern is needed:** The same failure mode occurs across multiple orchestration runs; the user manually adds the same HITL guidance repeatedly; token usage does not decrease across runs on similar prompts; the orchestrator makes the same decomposition mistakes on structurally similar tasks.
+- **Pattern is working:** `reflection.approved` events appear after completed runs; learnings from prior runs are retrieved at startup (`learnings.loaded` event); retry rates decrease across runs on similar task types; HITL escalation frequency decreases over time; the `learnings/` directory contains evidence-grounded proposals with clear approval status.
+- **Pattern is failing:** Proposals are consistently generic (no evidence citations); the user rejects most proposals (low signal-to-noise); learnings are approved but never loaded in future runs (broken retrieval); the reflection agent writes files directly despite `disallowedTools`.
+
+## Tradeoffs
+
+**Gain:** The orchestrator improves across runs without manual rule authoring. Failure modes are identified from execution traces (data-driven, not intuition-driven). The human approval gate ensures quality control while reducing the cognitive burden of identifying improvements -- the agent proposes, the human decides. Over 10+ runs, the compounding effect is significant: recurring failures get prevented, token-wasting patterns get eliminated, and decomposition quality improves.
+
+**Cost:** Adds a post-orchestration phase that requires human attention (reviewing 1-5 proposals). The reflection agent uses a capable model (not Haiku), adding token cost. The `learnings/` directory requires periodic review to prevent accumulation. The compounding benefit is only realized over multiple runs -- a single run does not recoup the reflection cost.
+
+## Related Patterns
+
+- **hydration-pattern** -- provides the execution trace data (checkpoint, execution log) that meta-prompting analyzes; meta-prompting reads what hydration writes
+- **hitl-protocol** -- HITL escalations are high-signal inputs for meta-prompting proposals; reducing future HITL frequency is a key success metric
+- **iterative-refinement** -- the human approval gate in meta-prompting mirrors the plan approval gate in iterative-refinement; both require explicit human confirmation before proceeding
+- **builder-validator** -- the reflection agent follows the validator's structural constraint (disallowedTools) to prevent direct file modification
+- **difficulty-routing** -- difficulty misclassifications (standard tasks that failed, hard tasks that passed first try) are a key analysis target for meta-prompting proposals
+- **spec-as-source-of-truth** -- the spec file's Execution Log is the primary data source for reflection; the spec must faithfully record execution events for meta-prompting to work
+
+## Source Anchors
+
+Community evidence (not yet implemented in orchestrator stages):
+- [From Prompts to AGENTS.md: What Survives Across Thousands of Runs](https://www.youtube.com/watch?v=aMwuPa6BnaM) -- AI Native Dev NYC talk by Tessl; meta-prompting loop: "please take a lessons learned out of your sessions, make five suggestions how to improve, wait for my approval"
+- [Tessl blog post: From Prompts to AGENTS.md](https://tessl.io/blog/from-prompts-to-agents-md-what-survives-across-thousands-of-runs/) -- written companion with detail on meta-prompting feedback loops (reactive and proactive)
+- [@zeeg: "if you're writing AGENTS.md files by hand, you're doing it wrong"](https://x.com/zeeg/status/2026401982798508513) -- counter-position to manual rule authoring; ETH Zurich shows auto-generated files can hurt, reinforcing the human approval gate
+- [Evaluating AGENTS.md: Are Repository-Level Context Files Helpful for Coding Agents?](https://arxiv.org/abs/2602.11988) -- ETH Zurich paper; LLM-generated context files reduce task success by 2-3% when redundant; supports the rule that proposals must target non-discoverable information only
+- [Stop Using /init for AGENTS.md -- Addy Osmani](https://addyosmani.com/blog/agents-md/) -- "auto-generated content isn't useless, it's redundant. The agent could find all of it anyway by reading the repo"; proposals should surface genuinely non-obvious learnings
+- [Please stop creating "memory for your agent" frameworks](https://www.reddit.com/r/ClaudeCode/comments/1r4asf6/please_stop_creating_memory_for_your_agent/) (256 pts, 132 comments) -- r/ClaudeCode; community pushback against automated rule generation without human oversight; validates the mandatory approval gate
+- [@addyosmani: Be careful with /init, treat AGENTS.md as a living list of codebase smells](https://x.com/addyosmani/status/2026172457233829922) -- three-layer hierarchy recommendation (protocol file, focused persona/skill files, maintenance subagent)

--- a/.claude/references/proposed-patterns/pattern-meta-prompting.md
+++ b/.claude/references/proposed-patterns/pattern-meta-prompting.md
@@ -2,6 +2,7 @@
 slug: meta-prompting
 display_name: "Meta-Prompting"
 one_liner: "After a completed orchestration, a reflection agent analyzes the execution trace and proposes rule improvements that compound the orchestrator's effectiveness across runs -- with mandatory human approval before any change is applied."
+intel_date: 2026-02-26
 slots:
   pattern_id: "## Pattern ID"
   quick_summary: "## Quick Summary"

--- a/.claude/references/proposed-patterns/pattern-no-fake-no-mock.md
+++ b/.claude/references/proposed-patterns/pattern-no-fake-no-mock.md
@@ -2,6 +2,7 @@
 slug: no-fake-no-mock
 display_name: "No Fake, No Mock, No Stub"
 one_liner: "Explicitly prohibit coding agents from faking, mocking, or stubbing in tests -- agents try hard to fulfill tasks including by writing fake tests that pass validation but verify nothing."
+intel_date: 2026-02-26
 slots:
   pattern_id: "## Pattern ID"
   quick_summary: "## Quick Summary"

--- a/.claude/references/proposed-patterns/pattern-no-fake-no-mock.md
+++ b/.claude/references/proposed-patterns/pattern-no-fake-no-mock.md
@@ -1,0 +1,123 @@
+---
+slug: no-fake-no-mock
+display_name: "No Fake, No Mock, No Stub"
+one_liner: "Explicitly prohibit coding agents from faking, mocking, or stubbing in tests -- agents try hard to fulfill tasks including by writing fake tests that pass validation but verify nothing."
+slots:
+  pattern_id: "## Pattern ID"
+  quick_summary: "## Quick Summary"
+  when_to_use: "## When To Use"
+  core_mechanism: "## Core Mechanism"
+  key_rules: "## Key Rules"
+  implementation_notes: "## Implementation Notes"
+  failure_modes: "## Failure Modes"
+  signals_diagnostics: "## Signals & Diagnostics"
+  tradeoffs: "## Tradeoffs"
+  related_patterns: "## Related Patterns"
+  source_anchors: "## Source Anchors"
+---
+
+## Pattern ID
+
+no-fake-no-mock
+
+## Quick Summary
+
+Models want to fulfill tasks and they try very hard. When asked to write tests, agents will work around difficulties by writing mocks and stubs that pass the test suite but don't test real behavior -- the test suite looks green but is worthless. The prohibition "No fake, no mock, no stub" must be an explicit rule in the builder's dispatch context, not an assumption. This rule appears independently across 3+ practitioner sources as a hard rule for testing with agents.
+
+## When To Use
+
+- Any task where the builder writes tests
+- Any validation where the validator checks test quality
+- Any AGENTS.md or builder agent definition that includes testing responsibilities
+- Integration test scenarios where real behavior must be verified
+- Continuous deployment pipelines where test quality directly gates production releases
+
+## Core Mechanism
+
+The prohibition is expressed as an explicit directive in the Builder agent's standing instructions or per-task dispatch context:
+
+**Builder Agent Definition (standing rule):**
+```markdown
+## Testing Rules
+
+1. No fake, no mock, no stub. You are a coding agent. You are able to code. Please code real code, no fakes.
+2. Integration tests must exercise real implementations.
+3. If external services require mocking, get explicit approval in the task description before using mocks.
+```
+
+**Validator Agent Checks:**
+- Grep test files for mock/stub/fake imports and patterns
+- Reject tests that use mocking frameworks unless explicitly approved
+- Flag test files that pass but have no assertions or trivial assertions
+- Verify that integration tests call real implementations
+
+The enforcement happens at two levels: (1) the Builder is instructed not to write mocks, and (2) the Validator is instructed to reject test code that contains mocks.
+
+## Key Rules
+
+1. The prohibition must be explicit in the builder's dispatch context -- not assumed or inferred.
+2. The validator must actively check for mocks/stubs in test code and reject them with a VERDICT: FAIL.
+3. The rule applies to integration tests especially -- unit test mocks of external services may be acceptable when explicitly approved in the task description.
+4. The builder agent definition should include this as a standing rule, not per-task instruction, so it applies universally.
+5. Test quality is part of the acceptance criteria -- passing tests that verify nothing is a validation failure.
+6. If the builder cannot write real tests without mocking external dependencies, it should report this limitation via TaskUpdate instead of silently introducing mocks.
+
+## Implementation Notes
+
+Add the "No fake, no mock, no stub" rule to the Builder agent's definition file (`.claude/agents/builder.md`):
+
+```markdown
+## Testing Principles
+
+- No fake, no mock, no stub. You are a coding agent capable of writing real code -- do not take shortcuts with test doubles.
+- Integration tests must exercise real implementations.
+- If an external dependency genuinely requires mocking, state this explicitly in TaskUpdate and wait for approval.
+```
+
+Update the Validator's checklist to include test quality checks:
+
+```markdown
+## Validation Checklist
+
+- [ ] All exported functions have JSDoc
+- [ ] All imports resolve correctly
+- [ ] Tests exist and pass
+- [ ] **Tests use real implementations (no mocks/stubs unless explicitly approved)**
+- [ ] Tests have meaningful assertions
+```
+
+The Validator can use `Grep` to search for patterns like `jest.mock(`, `vi.mock(`, `sinon.stub(`, `createMock`, `MockClass`, etc. If found, the Validator checks whether the task description explicitly authorized mocking. If not, the verdict is FAIL.
+
+## Failure Modes
+
+- **Silent Mock Introduction:** The Builder writes tests with extensive mocking but does not disclose this. The Validator does not check for mocks. The test suite passes but verifies nothing.
+- **Assumed Prohibition:** The orchestrator assumes agents will write real tests without stating it explicitly. The Builder interprets "write tests" as "make the test suite green" and uses the easiest path (mocks).
+- **Validator Overlooks Test Quality:** The Validator checks only that tests exist and pass, not whether they verify real behavior. Worthless tests pass validation.
+- **Legitimate Mocking Rejected:** The task requires testing against an external API that is unavailable in CI. The Builder tries to mock it but gets rejected. No exception process exists for legitimate cases.
+- **Rework Slop:** Tests pass initially but require extensive rework after deployment because they did not catch real bugs -- a form of "rework slop" where low-quality tests inflate perceived success rates.
+
+## Signals & Diagnostics
+
+- **Pattern is needed:** Test suites pass but production behavior breaks. Post-deployment bugs reveal that tests did not exercise real code paths. Test coverage is high but test quality is low.
+- **Pattern is working:** Validator logs show test quality checks being enforced. Builder occasionally reports via TaskUpdate that a task requires mocking and requests approval. Test failures catch real regressions before deployment.
+- **Pattern is failing:** Test suites remain green during refactoring that breaks functionality. Code review reveals extensive use of mocks in tests that claim to be integration tests. Deployment failures occur despite passing CI.
+
+## Tradeoffs
+
+**Gain:** Tests verify real behavior instead of passing trivially. Test suite quality directly improves production reliability. Agents cannot "cheat" by writing fake tests that satisfy validation without testing anything.
+
+**Cost:** Writing real tests may be harder or slower for agents. Some legitimate cases (external API dependencies, slow operations) may require mocking, necessitating an exception process. The Validator's checks become more complex and may need to parse test code semantically.
+
+## Related Patterns
+
+- **Builder/Validator** -- the prohibition is enforced by the Validator as part of test quality checks
+- **Spec Hardening** -- test quality requirements should be stated explicitly in the spec's acceptance criteria
+- **Meta-Prompting** -- the prohibition is a meta-rule about test writing that applies across all tasks
+
+## Source Anchors
+
+- [From Prompts to AGENTS.md: What Survives Across Thousands of Runs](https://www.youtube.com/watch?v=aMwuPa6BnaM) -- AI Native Dev NYC talk by Tessl; "No fake, no mock, no stub. You are a coding agent. You are able to code. Please code real code, no fakes."
+- [Tessl blog post: From Prompts to AGENTS.md](https://tessl.io/blog/from-prompts-to-agents-md-what-survives-across-thousands-of-runs/) -- testing rule #1 documented: "No fake, no mock, no stub"
+- [Codex vs Claude Code: which is the better AI coding agent?](https://www.builder.io/blog/codex-vs-claude-code) -- Steve Sewell notes agents routinely skip permissions and produce low-quality tests
+- [Getting AI to Work in Complex Codebases - HumanLayer](https://github.com/humanlayer/advanced-context-engineering-for-coding-agents) (1.5k stars) -- "rework slop" problem: AI tools ship code that passes tests but requires rework
+- [Effective context engineering for AI agents - Anthropic Engineering](https://www.anthropic.com/engineering/effective-context-engineering-for-ai-agents) -- sub-agent architecture and verification patterns

--- a/.claude/references/proposed-patterns/pattern-prompt-hop-chain-reduction.md
+++ b/.claude/references/proposed-patterns/pattern-prompt-hop-chain-reduction.md
@@ -2,6 +2,7 @@
 slug: prompt-hop-chain-reduction
 display_name: "Prompt Hop Chain Reduction"
 one_liner: "Collapse multi-file instruction chains into single-location inline instructions for gate behaviors, because each file-read hop degrades reliability geometrically."
+intel_date: 2026-02-26
 slots:
   pattern_id: "## Pattern ID"
   quick_summary: "## Quick Summary"

--- a/.claude/references/proposed-patterns/pattern-prompt-hop-chain-reduction.md
+++ b/.claude/references/proposed-patterns/pattern-prompt-hop-chain-reduction.md
@@ -1,0 +1,207 @@
+---
+slug: prompt-hop-chain-reduction
+display_name: "Prompt Hop Chain Reduction"
+one_liner: "Collapse multi-file instruction chains into single-location inline instructions for gate behaviors, because each file-read hop degrades reliability geometrically."
+slots:
+  pattern_id: "## Pattern ID"
+  quick_summary: "## Quick Summary"
+  when_to_use: "## When To Use"
+  core_mechanism: "## Core Mechanism"
+  key_rules: "## Key Rules"
+  implementation_notes: "## Implementation Notes"
+  failure_modes: "## Failure Modes"
+  signals_diagnostics: "## Signals & Diagnostics"
+  tradeoffs: "## Tradeoffs"
+  related_patterns: "## Related Patterns"
+  source_anchors: "## Source Anchors"
+---
+
+## Pattern ID
+
+prompt-hop-chain-reduction
+
+## Quick Summary
+
+When an LLM skill system distributes instructions across multiple files connected by "read this file, then follow its instructions" directives, each file-read hop is a failure point where the model may skip the read, synthesize what it thinks the file says, or merge instructions from multiple sources into a blended behavior that matches none of them. A 3-hop chain at 90% adherence per hop compounds to ~73% reliability -- a 17-point drop, not a 10-point drop. Hop Chain Reduction collapses these chains for critical-path behaviors: inline the minimum viable instruction set (2-3 concrete examples, exact tool call parameters, explicit stop barrier) into the primary skill file. Keep enhancement layers (full response banks, extended voice examples) in reference files as optional reads for variety.
+
+## When To Use
+
+- A behavior must execute deterministically (exact text, exact tool call, exact parameters) and the instructions are currently spread across 2+ files with read-then-follow directives
+- A gate behavior (tool call, precondition check, stop barrier) is failing intermittently and the instructions live in a reference file loaded via a hop chain
+- You observe intent summarization -- the LLM produces output that matches the general intent but skips the specific implementation (e.g., prints a question in prose instead of calling AskUserQuestion)
+- You see merge failures -- elements from different files blended into a single behavior that matches neither source
+- A critical instruction buried in a reference file is being ignored due to position bias or attention dilution
+
+## Core Mechanism
+
+**Gate vs Guide distinction:**
+
+A **gate** is a behavior that must execute exactly or the entire flow breaks (e.g., "call AskUserQuestion with header 'Topic'"). A **guide** shapes output quality but tolerates variation (e.g., "use newspaper slang"). Gates need inline instructions. Guides can live in reference files.
+
+**Compound failure rates:**
+
+| Chain Length | Adherence per Hop | Compound Reliability |
+|-------------|-------------------|---------------------|
+| 1 hop | 90% | 90% |
+| 2 hops | 90% | 81% |
+| 3 hops | 90% | 73% |
+| 4 hops | 90% | 66% |
+
+Hop chains degrade geometrically, not linearly. This is the core insight driving the pattern.
+
+**The reduction:**
+
+```
+BEFORE (3 hops, ~73% reliability):
+  SKILL.md: "No-Topic Hard Gate"
+    -> "Read references/investigate.md"
+      -> investigate.md Step 1: "Read no-topic-responses.md"
+        -> no-topic-responses.md: [10 response variations]
+          -> "Call AskUserQuestion(header='Topic')"
+
+AFTER (1 hop, ~90-95% reliability):
+  SKILL.md: "No Topic? Ask First, Do Nothing Else"
+    -> [3 inline response examples]
+    -> [Exact AskUserQuestion parameters]
+    -> "Stop. Resume at Route the Assignment after response."
+    -> (Optional: "For variety, read no-topic-responses.md")
+```
+
+**What to inline (minimum viable instruction set):**
+
+1. Concrete examples of expected output (2-3 variations, not the full bank)
+2. Exact tool call parameters (tool name, header, question text)
+3. Explicit stop condition ("stop and wait", "do not proceed")
+4. What comes next after the gate clears ("resume at Route the Assignment")
+
+**What stays in reference files (enhancement layer):**
+
+1. Full response banks (for variety beyond the inline examples)
+2. Edge case handling (unusual flag combinations)
+3. Detailed formatting templates
+4. Extended voice examples
+
+**The optional read pattern:**
+
+After inlining the critical behavior, add a non-blocking read directive:
+
+```markdown
+For additional response variety, you may read
+[references/no-topic-responses.md](references/no-topic-responses.md)
+and pick from its full bank instead of the examples above.
+```
+
+If the LLM reads it, more variety. If it doesn't, the behavior still works correctly.
+
+## Key Rules
+
+1. **Single-owner principle** -- every gate behavior has exactly one defining location in the prompt system. When the same gate appears in multiple files with different wording, the LLM may follow one, neither, or a blend.
+2. **Tool call as the gate** -- make the structured tool call the enforcement point, not printed text. The LLM can half-execute a text instruction (print text but skip the tool call). It cannot half-execute a tool call.
+3. **Stop barriers** -- an explicit "stop and wait" after a gate prevents the LLM from continuing without the gate being satisfied. List specific things not to do (read files, ask other questions, dispatch tasks) and state exactly when to resume.
+4. **Calm authority over shouting** -- Claude 4.5/4.6 models are more responsive to system prompts than earlier models. "MANDATORY HARD GATE" / "ALWAYS" / "NEVER" / "FORBIDDEN" language can cause erratic over-prompting backlash. Lead with what to do in calm, direct language.
+5. **Position-aware ordering** -- put gates before guides in the skill file. Put critical behaviors before optional enhancements. The no-topic gate must appear above the routing section, not below it.
+6. **Back-references over duplicates** -- when a reference file needs to acknowledge a gate already handled in SKILL.md, use a two-sentence back-reference ("Already handled by SKILL.md. If somehow empty, return to SKILL.md.") instead of a duplicate gate definition.
+
+## Implementation Notes
+
+**Decision flowchart for inline vs reference file:**
+
+```
+Is this behavior a GATE or a GUIDE?
+  |
+  +-- GUIDE -> Keep in reference file. Progressive disclosure works fine.
+  |
+  +-- GATE -> Does it require a specific tool call?
+        |
+        +-- Yes -> INLINE. Put exact tool parameters in SKILL.md.
+        |          Add stop barrier after the tool call.
+        |
+        +-- No -> Does it require specific text output?
+              |
+              +-- Yes -> INLINE 2-3 examples in SKILL.md.
+              |          Keep full bank in reference file as optional.
+              |
+              +-- No -> Is it a precondition check (if X then stop)?
+                    |
+                    +-- Yes -> INLINE. Put before the code path it guards.
+                    |
+                    +-- No -> Keep in reference file with clear instructions.
+```
+
+**Case study -- Newsroom no-topic gate:**
+
+The bug: `/newsroom:investigate` with no topic should print one approved response and call AskUserQuestion. Instead, the LLM printed generic text ("The /newsroom:investigate skill has been loaded...") with no structured tool call, and sometimes asked about depth/sources before capturing a topic.
+
+Root cause: 3-hop chain with two competing gate definitions (SKILL.md vs investigate.md) using different wording, plus the routing section appearing BEFORE the gate in SKILL.md (position bias).
+
+The fix (three surgical changes):
+1. **SKILL.md** -- moved gate above routing, inlined 3 response examples + exact AskUserQuestion parameters, added stop barrier, made full response bank an optional read
+2. **investigate.md** -- replaced duplicate gate with back-reference ("Already handled by SKILL.md")
+3. **Tone** -- replaced "MANDATORY HARD GATE" with "No Topic? Ask First, Do Nothing Else"
+
+**Stop barrier example:**
+
+```markdown
+Then stop and wait. Do not read any reference files. Do not ask about
+depth, sources, or mode. Do not call Task. Do not print anything else.
+Resume at "Route the Assignment" only after the user responds with a topic.
+```
+
+Key elements: imperative verb ("stop"), exhaustive prohibition of specific next-actions, explicit resume condition with exact location.
+
+**Calm authority example:**
+
+Before (over-prompted):
+```markdown
+## MANDATORY HARD GATE
+**ALWAYS** use AskUserQuestion. **NEVER** skip. **MUST** call.
+**FORBIDDEN:** Generic preambles, proceeding without topic.
+```
+
+After (calm, direct):
+```markdown
+## No Topic? Ask First, Do Nothing Else
+When $ARGUMENTS is empty, do these two things and stop:
+1. Print one of these lines: [examples]
+2. Call AskUserQuestion with header "Topic"
+Then stop and wait.
+```
+
+## Failure Modes
+
+- **Skip-Read Failure:** The LLM skips a file read entirely and synthesizes behavior from the instruction name. Output matches the general intent but not the specific implementation. Tool calls are absent or have wrong parameters.
+- **Merge Failure:** Instructions from multiple files get blended into a single behavior. Elements from different sections/files combine in unexpected ways (e.g., asking about depth/sources before capturing topic).
+- **Position Bias Failure:** Instructions that appear later in loaded context get less attention. Early instructions in SKILL.md followed perfectly; instructions in the third reference file followed loosely or not at all.
+- **Over-Prompting Backlash:** Excessive MANDATORY/NEVER/CRITICAL language causes the LLM to focus on prohibitions rather than constructive instructions. It knows what NOT to do but not what TO do. Particularly acute on Claude 4.5/4.6.
+- **Duplicate Gate Confusion:** The same gate defined in two files with slightly different wording. The LLM follows one version, the other, or a hybrid that matches neither.
+- **Implicit File-Read Dependencies:** "Read investigate.md for the full workflow" without indicating which parts are critical. The LLM skims or summarizes rather than following step-by-step.
+
+## Signals & Diagnostics
+
+- **Pattern is needed:** Gate behaviors fail intermittently. The LLM produces output matching the general intent but missing exact tool calls or exact text. You find the same behavior defined in two or more files with different wording. Critical instructions live 2+ hops deep in reference files.
+- **Pattern is working:** Gate behaviors execute deterministically. Tool calls include exact parameters specified in the inline instruction. Stop barriers prevent premature continuation. Response variety is lower (2-3 inline examples) but correctness is high.
+- **Pattern is failing:** Inline examples are too few and responses feel repetitive (add more inline or check the optional read). Over-inlining bloats the primary skill file and pushes later sections into attention dilution territory. Back-references in reference files are ignored and the LLM re-invents the gate behavior.
+
+## Tradeoffs
+
+**Gain:** Gate reliability rises from ~73% (3-hop) to ~90-95% (1-hop inline). Debugging is easier -- one file to check instead of chasing through a chain. Stop barriers prevent the most common failure mode (premature continuation past an unsatisfied gate).
+
+**Cost:** Token cost per invocation increases slightly (inline examples are always loaded, not demand-loaded). Maintainability is harder -- inline examples duplicate data from the reference file. Response variety is reduced to 2-3 inline variations unless the LLM reads the optional reference file. Over-inlining can bloat SKILL.md and cause attention dilution for later sections, trading one problem for another.
+
+**The sweet spot:** Inline the minimum viable gate (2-3 examples, exact tool params, stop barrier) and keep the enhancement layer in reference files with optional reads. This balances reliability against token cost and maintainability.
+
+## Related Patterns
+
+- **Context Engineering** -- hop chain reduction is a form of context quality management; reducing hops reduces the chance of context pollution from intermediate file reads
+- **Plugin Architecture** -- progressive disclosure (SKILL.md + references/) creates hop chains by design; this pattern identifies when to break that convention for gates
+- **Higher-Order Prompt** -- HOP variables are always inlined at the top of the skill file, consistent with the principle that critical configuration should not live behind file reads
+- **Spec as Source of Truth** -- spec files are re-read from disk at wave boundaries for the same reason gates are inlined: critical information should not depend on indirect access
+
+## Source Anchors
+
+- `side-quest-plugins/docs/prompt-hop-chain-reduction-spec.md` -- full Staff Engineer specification with compound failure rate model, failure taxonomy, Anthropic guidance citations, and newsroom case study
+- `side-quest-plugins/plugins/newsroom/skills/the-desk/SKILL.md` -- reference implementation of the inlined no-topic gate
+- `side-quest-plugins/plugins/newsroom/skills/the-desk/references/investigate.md` -- reference implementation of the back-reference pattern
+- [Anthropic Prompting Best Practices](https://docs.anthropic.com/en/docs/build-with-claude/prompt-engineering/system-prompts) -- "Be clear and direct", sequential steps for order-dependent behavior, long context positioning, Claude 4.5/4.6 over-prompting warnings
+- [Atla AI: Why LLM Agents Still Fail](https://atla-ai.com/post/why-llm-agents-still-fail) -- compound failure rates across multi-step tasks
+- [Lakera: Prompt Engineering Guide](https://lakera.ai/blog/prompt-engineering-guide) -- defensive prompting, structural guards

--- a/.claude/references/proposed-patterns/pattern-rules-as-exploration-enablers.md
+++ b/.claude/references/proposed-patterns/pattern-rules-as-exploration-enablers.md
@@ -1,0 +1,118 @@
+---
+slug: rules-as-exploration-enablers
+display_name: "Rules as Exploration Enablers"
+one_liner: "Adding AGENTS.md rules to agents counterintuitively increases token usage and runtime, but significantly improves solution quality -- rules reduce environmental uncertainty, freeing agents to explore deeper solution architectures."
+slots:
+  pattern_id: "## Pattern ID"
+  quick_summary: "## Quick Summary"
+  when_to_use: "## When To Use"
+  core_mechanism: "## Core Mechanism"
+  key_rules: "## Key Rules"
+  implementation_notes: "## Implementation Notes"
+  failure_modes: "## Failure Modes"
+  signals_diagnostics: "## Signals & Diagnostics"
+  tradeoffs: "## Tradeoffs"
+  related_patterns: "## Related Patterns"
+  source_anchors: "## Source Anchors"
+---
+
+## Pattern ID
+
+rules-as-exploration-enablers
+
+## Quick Summary
+
+Adding AGENTS.md rules counterintuitively increases token usage and runtime, but significantly improves solution quality. The mechanism: rules reduce environmental uncertainty -- the agent stops spending tokens searching randomly for configuration, API keys, or framework patterns, and instead spends those tokens exploring deeper solution architectures and better implementations. The Tessl experiment found that guiding the model to better solutions increased costs and runtime, but also increased quality scores. The paradox resolves when you realize that the "saved" tokens from reduced searching are reinvested into better solutions, not eliminated.
+
+## When To Use
+
+- Projects where solution quality matters more than minimizing token cost
+- Complex environments with many configuration files, API keys, or framework conventions where agents waste tokens searching
+- Long-running projects where higher upfront token cost is amortized across many runs
+- Situations where random exploration leads to poor solutions (shallow architectures, missed patterns)
+- When agents repeatedly fail to find configuration or integration points without guidance
+
+## Core Mechanism
+
+Without AGENTS.md rules, agents face high environmental uncertainty. They must search the codebase to find:
+- Where configuration files live
+- How to access API keys
+- Which framework patterns to follow
+- Where tests should be placed
+- How modules are structured
+
+This search consumes tokens but often yields shallow or incorrect answers because the agent has no ground truth to validate against.
+
+With AGENTS.md rules, the agent receives direct answers to environmental questions:
+- "Configuration is in `config/app.ts`"
+- "API keys are in `.env.local`"
+- "Use React hooks, not class components"
+- "Tests go in `__tests__/` adjacent to source files"
+
+This eliminates random searching. The tokens that would have been spent searching are now available for deeper exploration: evaluating multiple architectural approaches, considering edge cases, implementing more robust error handling.
+
+The counterintuitive result: total token usage goes UP (because the agent now explores more deeply), but solution quality also goes UP (because exploration is focused on architecture, not configuration hunting).
+
+Research supports this: the ETH Zurich paper found that AGENTS.md files improve performance by 2.7% when repos have no other documentation, and reduce median wall-clock runtime by 28.64%. Emergent Mind reported a 16.58% reduction in output token consumption when AGENTS.md files are present. The Tessl experiment found increased token usage but higher quality scores.
+
+## Key Rules
+
+1. Rules should eliminate environmental uncertainty -- tell agents where things are, not what to build.
+2. Expect token usage to increase when adding AGENTS.md -- this is not a failure signal if solution quality improves.
+3. Measure quality, not just cost -- cheaper solutions are not always better solutions.
+4. Focus rules on configuration, location, and conventions -- these are the high-uncertainty, low-value searches that waste tokens.
+5. Do not over-constrain architecture -- rules should free exploration, not eliminate it.
+6. Update AGENTS.md when agents waste tokens searching for something that could be documented.
+
+## Implementation Notes
+
+Audit agent traces to identify high-uncertainty, low-value searches:
+- Reading multiple config files before finding the right one
+- Searching for API key locations across `.env`, `config/`, `src/constants/`
+- Trying multiple framework patterns before settling on one
+- Exploring directory structure to determine test placement
+
+For each identified search, add a rule to AGENTS.md:
+- "Configuration lives in `config/app.ts`"
+- "API keys are in `.env.local` and accessed via `process.env`"
+- "Use React functional components with hooks"
+- "Place tests in `__tests__/` adjacent to source files"
+
+Monitor both token usage and solution quality after adding rules. If token usage increases but quality improves, the pattern is working. If both increase, the rules may be over-constraining -- remove or refine them.
+
+Lance Cleveland's recommendation: even a rudimentary AGENTS.md can significantly improve output. Start simple -- document the 3-5 highest-uncertainty questions agents repeatedly face.
+
+## Failure Modes
+
+- **Over-constraining:** Rules eliminate architectural exploration entirely. Agent follows a prescribed path that happens to be suboptimal for the current task.
+- **Stale rules:** AGENTS.md documents old configuration locations or obsolete framework patterns. Agent wastes tokens following outdated guidance, then correcting course.
+- **Cost obsession:** Engineering team sees increased token usage after adding AGENTS.md and removes it, ignoring quality improvements. Agents return to random searching and shallow solutions.
+- **Wrong rules:** AGENTS.md contains incorrect information (wrong config path, wrong framework convention). Agent follows bad guidance and produces broken output.
+- **Rule bloat:** AGENTS.md accumulates too many low-value rules. Token budget spent loading rules exceeds tokens saved from reduced searching.
+
+## Signals & Diagnostics
+
+- **Pattern is needed:** Agent traces show repeated searching for configuration, API keys, or framework patterns. Solutions are shallow or miss obvious patterns. Agents frequently fail to find integration points without extensive trial and error.
+- **Pattern is working:** Token usage increases slightly but solution quality improves significantly. Agents spend fewer turns searching and more turns implementing. Solutions demonstrate deeper architectural thinking and better error handling.
+- **Pattern is failing:** Token usage increases without quality improvement. Agents follow prescribed paths that produce suboptimal solutions. Agent traces show no evidence of architectural exploration -- just rote execution of rules.
+
+## Tradeoffs
+
+**Gain:** Agents explore solution space more deeply instead of wasting tokens on environmental searches. Solution quality improves. Time-to-solution decreases despite higher token usage because agents make fewer false starts. Learnings compound -- each rule improves all future runs.
+
+**Cost:** Higher token usage per run. AGENTS.md maintenance overhead. Risk of over-constraining if rules are too prescriptive. Initial engineering investment to identify high-uncertainty searches and document them.
+
+## Related Patterns
+
+- **Spec Hardening** -- validated patterns from completed tasks inform AGENTS.md rules
+- **Difficulty Routing** -- complex tasks benefit more from rules because environmental uncertainty is higher
+- **Three-Layer Influence** -- AGENTS.md is the durable layer where rules should live
+- **Hierarchical Persistent Memory** -- rules can be layered (global vs component-specific) to minimize over-constraining
+
+## Source Anchors
+
+- [From Prompts to AGENTS.md: What Survives Across Thousands of Runs](https://www.youtube.com/watch?v=aMwuPa6BnaM) -- AI Native Dev NYC talk by Tessl; experiment results showing rules increase tokens but improve quality
+- [Tessl blog post: From Prompts to AGENTS.md](https://tessl.io/blog/from-prompts-to-agents-md-what-survives-across-thousands-of-runs/)
+- [Evaluating AGENTS.md: Are Repository-Level Context Files Helpful for Coding Agents?](https://arxiv.org/abs/2602.11988) -- ETH Zurich paper; context files improve performance by 2.7% when repos have no other documentation; median wall-clock runtime reduction of 28.64%
+- [AGENTS.md Files: AI Agent Configuration -- Emergent Mind](https://www.emergentmind.com/topics/agents-md-files) -- "16.58% reduction in output token consumption" when AGENTS.md files present
+- [Improve Your AI Assisted Coding With AGENTS.md -- Lance Cleveland](https://lancecleveland.com/2026/02/24/improve-your-ai-assisted-coding-with-agents-md/) -- "even a rudimentary AGENTS.md can significantly improve the output"

--- a/.claude/references/proposed-patterns/pattern-rules-as-exploration-enablers.md
+++ b/.claude/references/proposed-patterns/pattern-rules-as-exploration-enablers.md
@@ -2,6 +2,7 @@
 slug: rules-as-exploration-enablers
 display_name: "Rules as Exploration Enablers"
 one_liner: "Adding AGENTS.md rules to agents counterintuitively increases token usage and runtime, but significantly improves solution quality -- rules reduce environmental uncertainty, freeing agents to explore deeper solution architectures."
+intel_date: 2026-02-26
 slots:
   pattern_id: "## Pattern ID"
   quick_summary: "## Quick Summary"

--- a/.claude/references/proposed-patterns/pattern-self-reflecting-analytics.md
+++ b/.claude/references/proposed-patterns/pattern-self-reflecting-analytics.md
@@ -1,0 +1,174 @@
+---
+slug: self-reflecting-analytics
+display_name: "Self-Reflecting Analytics"
+one_liner: "The orchestrator collects structured metrics from its own execution traces -- token usage, tool calls, task durations, retry rates -- to ground future orchestration decisions in data rather than intuition."
+slots:
+  pattern_id: "## Pattern ID"
+  quick_summary: "## Quick Summary"
+  when_to_use: "## When To Use"
+  core_mechanism: "## Core Mechanism"
+  key_rules: "## Key Rules"
+  implementation_notes: "## Implementation Notes"
+  failure_modes: "## Failure Modes"
+  signals_diagnostics: "## Signals & Diagnostics"
+  tradeoffs: "## Tradeoffs"
+  related_patterns: "## Related Patterns"
+  source_anchors: "## Source Anchors"
+---
+
+## Pattern ID
+
+self-reflecting-analytics
+
+## Quick Summary
+
+Self-Reflecting Analytics turns the orchestrator's own execution traces into structured data that informs future runs. After an orchestration completes, an analytics script parses the spec file's Execution Log and Hydration Checkpoint sections (or raw session traces from `~/.claude` and `~/.codex`) and extracts KPIs: per-task token usage, tool call counts, wall-clock duration, retry rates, HITL escalation frequency, and difficulty classification accuracy. The output is a JSON report that serves two purposes: (1) the human reviews it to understand orchestration performance, and (2) future orchestration runs can read historical reports to calibrate decisions -- which tasks to route to Codex, how to estimate token budgets, which team profiles produce the highest first-pass success rates. Without this pattern, orchestration decisions are based on intuition. With it, they are data-driven.
+
+## When To Use
+
+- After any completed orchestration run where you want to understand performance characteristics
+- When difficulty-routing classifications need calibration (which tasks tagged `standard` actually required retries? which tasks tagged `hard` passed first try?)
+- When token budget estimates in the iterative-refinement step need grounding in actual usage data
+- When comparing team profiles or builder models to determine which produces the best cost/quality ratio
+- When building a historical dataset across multiple runs to surface cross-run trends
+- When the `--analytics` flag is passed, or automatically after every run when configured
+
+## Core Mechanism
+
+The analytics pipeline has three stages:
+
+**Stage 1: Trace Collection**
+Read execution data from one or more sources:
+- **Primary:** The spec file's Execution Log section -- structured events emitted by the orchestrator during the run (agent.dispatched, spec.reread, plan.approved, verdict events, retry events, HITL events)
+- **Secondary:** Raw session traces from `~/.claude/projects/` or `~/.codex/` -- JSONL files containing every API call, tool use, and response
+- **Tertiary:** Hydration Checkpoint section -- task status transitions, retry counts, timing data
+
+**Stage 2: KPI Extraction**
+Parse traces into structured metrics:
+
+```json
+{
+  "orchestration_id": "rest-api-2026-02-25",
+  "summary": {
+    "total_tasks": 5,
+    "total_waves": 3,
+    "total_duration_seconds": 847,
+    "total_tokens": 142300,
+    "first_pass_success_rate": 0.6,
+    "retry_rate": 0.4,
+    "hitl_escalations": 1
+  },
+  "per_task": [
+    {
+      "task_id": "define-user-types",
+      "difficulty": "standard",
+      "builder": "builder",
+      "tokens": 18200,
+      "duration_seconds": 95,
+      "retries": 0,
+      "verdict": "PASS",
+      "validator_failure_reasons": []
+    },
+    {
+      "task_id": "implement-auth-middleware",
+      "difficulty": "hard",
+      "builder": "codex",
+      "tokens": 45800,
+      "duration_seconds": 312,
+      "retries": 2,
+      "verdict": "PASS",
+      "validator_failure_reasons": [
+        "Missing verifyToken export",
+        "No error handling for expired tokens"
+      ]
+    }
+  ],
+  "difficulty_accuracy": {
+    "standard_passed_first_try": 3,
+    "standard_needed_retry": 0,
+    "hard_passed_first_try": 1,
+    "hard_needed_retry": 1
+  }
+}
+```
+
+**Stage 3: Report Output**
+Write the JSON report to `specs/analytics/<orchestration-id>.json`. Optionally produce a human-readable summary to stdout.
+
+## Key Rules
+
+1. Analytics scripts are CLI tools with a documented contract: they take a spec file path (or session-id) as input and output JSON to stdout or a file. No interactive prompts, no side effects.
+2. Every analytics script must include a self-check: run one verified example after changes to confirm output format is correct. This prevents silent breakage.
+3. Analytics output is append-only and never modifies the spec file or any orchestrator infrastructure. Analytics reads; it never writes to orchestration state.
+4. Scope analytics rules narrowly in AGENTS.md -- "applies to tools in scripts/analytics/" not globally. Prevent analytics rules from interfering with orchestration rules.
+5. Historical analytics data lives in `specs/analytics/` alongside spec files -- co-located with the runs they describe.
+6. The analytics script must handle both Claude and Codex session formats -- session trace structures differ between agents.
+
+## Implementation Notes
+
+**Script contract:** Following the pattern from the talk, each analytics script:
+- Documents its arguments and example usage in a docstring
+- Takes a single required parameter (spec file path or session-id)
+- Outputs structured JSON
+- Exits 0 on success, non-zero on failure
+- Can be invoked by the orchestrator or by a human
+
+**AGENTS.md scoping:** The analytics skill gets its own scoped AGENTS.md (or a section in the orchestrator's references) that documents:
+- Scope: which directories and scripts it applies to
+- Boundaries: what it can and cannot modify (read-only with respect to orchestration state)
+- CLI contract: argument format and output format for each script
+- Self-check requirement: "run one verified example after changes"
+- Script catalog: list of available analytics tools
+
+**Session trace locations:**
+- Claude Code: `~/.claude/projects/<project>/` contains JSONL session transcripts
+- Codex CLI: `~/.codex/` contains rollout JSONL files
+- Orchestrator spec files: `specs/` directory in the project
+
+**Cross-run aggregation:** When multiple analytics reports exist in `specs/analytics/`, a separate aggregation script can compute cross-run trends: average retry rates by difficulty tag, token usage trends over time, team profile comparison, builder model comparison. This is the data that calibrates difficulty-routing and token estimation.
+
+**Integration with meta-prompting:** Analytics reports are high-signal input for the meta-prompting reflection agent. Instead of analyzing raw execution traces, the reflection agent reads the pre-computed KPIs. This reduces the reflection agent's context window usage and improves proposal quality -- it reasons over structured data, not raw logs.
+
+**Event emission:**
+- `analytics.started` -- analytics script begins execution
+- `analytics.complete` -- analytics report written successfully
+- `analytics.error` -- analytics script failed (non-zero exit)
+
+## Failure Modes
+
+- **Analytics script modifies orchestration state:** An analytics tool that writes to the spec file or modifies task status corrupts the orchestration. Analytics must be read-only.
+- **Unscoped AGENTS.md rules:** Analytics rules placed in the root AGENTS.md interfere with builder or validator behavior. Scope rules to the analytics directory only.
+- **No self-check on script changes:** An analytics script is modified but the output format silently changes. Downstream consumers (meta-prompting, cross-run aggregation) parse the wrong structure. The self-check requirement catches this.
+- **Missing session traces:** Claude Code or Codex may not retain session traces beyond a certain age or size limit. Analytics should degrade gracefully -- report what is available, flag what is missing.
+- **Token counting inaccuracy:** Different session formats report token usage differently (input tokens, output tokens, cache tokens). The analytics script must normalize to a consistent accounting method.
+
+## Signals & Diagnostics
+
+- **Pattern is needed:** Orchestration decisions (difficulty routing, token estimation, team selection) are based on intuition or fixed heuristics; no data exists to calibrate them; the same misclassifications recur across runs.
+- **Pattern is working:** Analytics reports appear in `specs/analytics/` after each run; difficulty-routing accuracy improves over time as classifications are calibrated against actual retry data; token estimates in iterative-refinement converge toward actual usage; meta-prompting proposals cite analytics data as evidence.
+- **Pattern is failing:** Analytics scripts are present but never run (no reports generated); reports exist but are never read by downstream consumers; analytics rules are scoped globally and interfere with builders; self-check is skipped and output format drifts silently.
+
+## Tradeoffs
+
+**Gain:** Orchestration decisions become data-driven. Difficulty routing is calibrated against actual retry rates, not heuristics. Token estimation converges toward real usage patterns. Team profile comparisons are grounded in cost/quality metrics. The meta-prompting reflection agent receives structured KPIs instead of raw traces. Over 10+ runs, the compounding effect is significant -- the orchestrator learns which configurations work best for which task types.
+
+**Cost:** Requires building and maintaining analytics scripts. Session trace formats may change with agent updates, requiring script maintenance. Cross-run aggregation adds storage and processing overhead. The analytics phase adds post-orchestration latency (typically seconds, not minutes). The primary cost is the initial investment in building the analytics infrastructure -- ongoing cost is low.
+
+## Related Patterns
+
+- **meta-prompting** -- consumes analytics reports as structured input for reflection proposals; analytics provides the evidence that meta-prompting reasons over
+- **difficulty-routing** -- analytics data calibrates the difficulty rubric; tasks classified `standard` that needed retries suggest the rubric's hard-signal thresholds need adjustment
+- **iterative-refinement** -- token estimation in Step 8 can be calibrated against historical analytics data; actual usage replaces the flat 4,500-token-per-task estimate
+- **team-profiles** -- cross-run analytics comparing team profiles reveals which builder/validator combinations produce the best first-pass success rates
+- **hydration-pattern** -- the Hydration Checkpoint provides per-task timing and retry data that analytics consumes; hydration writes, analytics reads
+
+## Source Anchors
+
+Community evidence (not yet implemented in orchestrator stages):
+- [From Prompts to AGENTS.md: What Survives Across Thousands of Runs](https://www.youtube.com/watch?v=aMwuPa6BnaM) -- AI Native Dev NYC talk by Tessl; slide at ~18:00 shows three-panel architecture: Meta-Prompt, Analytics Script (`home-session-metrics.py`), and scoped AGENTS.md (`NY-Analytics v1`)
+- [Tessl blog post: From Prompts to AGENTS.md](https://tessl.io/blog/from-prompts-to-agents-md-what-survives-across-thousands-of-runs/) -- written companion; "system prompts define general behavior; AGENTS.md encodes project-, component-, and tool-specific memory"
+- The slide's AGENTS.md shows the exact scoping pattern: "Applies to all tools in ny/scripts/[metrics|benchmarks]", "Supports NY experiments only; no global Agent-Squad changes", CLI Contract requirement, Self-Check requirement, Script Catalog
+- Speaker: "If you want on a later point have some better decision grounding for orchestrating more of them, then you need some data-driven approach"
+- [Effective context engineering for AI agents -- Anthropic Engineering](https://www.anthropic.com/engineering/effective-context-engineering-for-ai-agents) -- Anthropic's canonical take on context management; sub-agent architecture returns 1,000-2,000 token summaries; "minimum viable context" principle
+- [Getting AI to Work in Complex Codebases -- HumanLayer](https://github.com/humanlayer/advanced-context-engineering-for-coding-agents) (1.5k stars, 107 forks) -- Frequent Intentional Compaction (FIC) pattern; "deliberately structuring how you feed context to the AI throughout the development process"
+- [Support AGENTS.md -- Issue #6235 -- anthropics/claude-code](https://github.com/anthropics/claude-code/issues/6235) (2,838+ upvotes) -- community demand for native AGENTS.md support; workarounds include `@AGENTS.md` import, symlinks, and SessionStart hooks

--- a/.claude/references/proposed-patterns/pattern-self-reflecting-analytics.md
+++ b/.claude/references/proposed-patterns/pattern-self-reflecting-analytics.md
@@ -2,6 +2,7 @@
 slug: self-reflecting-analytics
 display_name: "Self-Reflecting Analytics"
 one_liner: "The orchestrator collects structured metrics from its own execution traces -- token usage, tool calls, task durations, retry rates -- to ground future orchestration decisions in data rather than intuition."
+intel_date: 2026-02-26
 slots:
   pattern_id: "## Pattern ID"
   quick_summary: "## Quick Summary"

--- a/.claude/references/proposed-patterns/pattern-skill-bootstrapping.md
+++ b/.claude/references/proposed-patterns/pattern-skill-bootstrapping.md
@@ -1,0 +1,181 @@
+---
+slug: skill-bootstrapping
+display_name: "Skill Bootstrapping"
+one_liner: "A single meta-prompt that produces both a capability artifact (script, tool, agent) AND the AGENTS.md rules for future agents to use it -- creating a self-bootstrapping loop where each cycle adds compound capability."
+slots:
+  pattern_id: "## Pattern ID"
+  quick_summary: "## Quick Summary"
+  when_to_use: "## When To Use"
+  core_mechanism: "## Core Mechanism"
+  key_rules: "## Key Rules"
+  implementation_notes: "## Implementation Notes"
+  failure_modes: "## Failure Modes"
+  signals_diagnostics: "## Signals & Diagnostics"
+  tradeoffs: "## Tradeoffs"
+  related_patterns: "## Related Patterns"
+  source_anchors: "## Source Anchors"
+---
+
+## Pattern ID
+
+skill-bootstrapping
+
+## Quick Summary
+
+Skill Bootstrapping is the generative pattern behind self-reflecting analytics, orchestration skills, and any situation where a coding agent builds a new tool. The core insight: asking an agent to build a tool is only half the job. The other half is asking it to simultaneously produce the rules and documentation so that future agents (including itself in future sessions) know the tool exists, how to invoke it, and what constraints apply. A single meta-prompt produces a triple: (1) the capability artifact -- a script, tool, or agent definition, (2) the usage rules -- an AGENTS.md section or skill reference scoped to the artifact's directory, and (3) a self-check -- a verified example proving the artifact works. This triple is the minimum viable unit for compound capability. Without the rules, the artifact is invisible to future agents. Without the self-check, the artifact may be broken. Without the artifact, the rules describe nothing.
+
+## When To Use
+
+- When building any new tool, script, or agent definition that other agents will use in future sessions
+- When the orchestrator needs a new skill and the current session should produce both the implementation and the documentation
+- When a capability gap is identified (by meta-prompting, by the user, or during a failed orchestration) and needs to be filled with a self-documenting solution
+- When onboarding a new external tool (API, CLI, service) into the agent's skill set -- the bootstrap prompt produces the wrapper script and the rules simultaneously
+- When the output of a meta-prompting proposal is "pattern gap: need a tool for X" -- skill bootstrapping is how you fill that gap
+
+## Core Mechanism
+
+The Skill Bootstrapping triple is produced by a single meta-prompt with three explicit deliverables:
+
+**Deliverable 1: The Capability Artifact**
+A script, tool, or agent definition file. This is the thing that does the work.
+
+Requirements:
+- CLI contract: documented arguments, example usage, JSON output where applicable
+- Standalone: runs independently with no implicit dependencies on the current session's context
+- Idempotent where possible: running it twice with the same input produces the same output
+
+**Deliverable 2: The Usage Rules (Scoped AGENTS.md)**
+A rules section or file that documents:
+- **Scope:** which directories and files the rules apply to (never global unless genuinely global)
+- **Boundaries:** what the tool can and cannot do, what side effects it has, what it must never modify
+- **CLI Contract:** argument format, output format, example invocation
+- **Self-Check Requirement:** "Run one verified example after changes"
+- **Script/Tool Catalog:** updated list of available tools in this scope
+
+The rules are placed at the appropriate level in the hierarchy:
+- Tool-specific rules: alongside the tool in its directory
+- Component-level rules: in the component's AGENTS.md section
+- Project-level rules: in the project root (rare -- only for tools used everywhere)
+
+**Deliverable 3: The Self-Check**
+A concrete, runnable verification that proves the artifact works:
+- For scripts: a sample invocation with expected output
+- For agent definitions: a test dispatch with a trivial task
+- For API wrappers: a smoke test against a known endpoint
+
+The self-check is run immediately after the artifact is created. If it fails, the artifact is not considered bootstrapped.
+
+**The Bootstrapping Loop:**
+
+```
+Meta-Prompt (human or meta-prompting proposal)
+    |
+    v
+Agent produces: artifact + rules + self-check
+    |
+    v
+Self-check passes? --NO--> Agent fixes artifact, re-runs check
+    |
+   YES
+    |
+    v
+Rules are visible to future agents
+    |
+    v
+Future agent encounters a task where the tool is relevant
+    |
+    v
+Future agent reads rules, invokes artifact
+    |
+    v
+Artifact output informs future decisions
+    |
+    v
+New capability gap identified --> new meta-prompt --> cycle repeats
+```
+
+Each cycle adds a new capability to the agent's skill set. Over N cycles, the agent's available tools grow, and each tool is self-documenting and self-verifying.
+
+## Key Rules
+
+1. **Triple or nothing:** Never produce an artifact without rules. Never produce rules without an artifact. Never skip the self-check. All three are required for a skill to be considered bootstrapped.
+2. **Scope rules narrowly:** Rules for a new analytics script apply to `scripts/analytics/`, not to the entire project. Overly broad rules interfere with unrelated agents and tools.
+3. **Self-check runs immediately:** The self-check is not deferred -- it runs as part of the bootstrapping process. A skill that has not been verified is not a skill.
+4. **CLI contract is mandatory:** Every artifact that other agents will invoke must document its arguments and output format. Agents cannot use tools they cannot invoke correctly.
+5. **Catalog updates are part of bootstrapping:** When a new tool is added, the tool catalog in the scoped AGENTS.md must be updated. A tool not in the catalog is invisible to future agents scanning for available tools.
+6. **Boundary documentation prevents blast-radius creep:** Explicitly state what the tool does NOT do and what it must NOT modify. Future agents respect documented boundaries; they probe undocumented ones.
+
+## Implementation Notes
+
+**Meta-prompt template for skill bootstrapping:**
+
+A meta-prompt that reliably produces the triple follows this structure:
+
+```
+Build [tool description]. Requirements:
+
+1. Create [artifact path] that [behavior description].
+   - Takes [input format] as input
+   - Outputs [output format]
+   - [specific constraints]
+
+2. Add rules to [AGENTS.md location] documenting:
+   - Scope: which directories this applies to
+   - Boundaries: what this tool must never modify
+   - CLI contract: arguments, output format, example invocation
+   - Self-check: one verified example command
+
+3. Run the self-check and confirm the output matches expectations.
+```
+
+The three numbered deliverables make the triple explicit. Agents that receive a single vague instruction ("build an analytics tool") often produce the artifact but skip the rules and self-check.
+
+**Interaction with meta-prompting:** When a meta-prompting proposal identifies a "pattern gap," the next step is a skill bootstrapping prompt that fills the gap. The meta-prompting pattern identifies what is needed; skill bootstrapping produces it. The two patterns form a discovery-to-implementation pipeline.
+
+**Interaction with team-profiles:** Skill bootstrapping can produce new agent definitions (builders, validators, specialized agents). When a new agent type is bootstrapped, it requires both the agent definition file (`.claude/agents/<name>.md`) and a team profile update (`.claude/skills/orchestrator/teams/<name>.md`). The triple becomes a quadruple for agent bootstrapping: artifact + rules + team profile + self-check.
+
+**Versioning:** The scoped AGENTS.md should include a version tag (e.g., `NY-Analytics (v1)` from the talk's slide). When the artifact changes significantly, bump the version. This signals to agents (and humans) that the rules may have changed.
+
+**Progressive disclosure integration:** In side-quest-plugins, bootstrapped skills can use the references/ pattern -- the main SKILL.md documents the tool's existence (~100 tokens), and the full CLI contract, examples, and constraints live in a references/ file loaded only when the tool is invoked.
+
+## Failure Modes
+
+- **Artifact without rules:** The tool exists but no AGENTS.md documents it. Future agents do not know the tool is available. The capability is invisible -- it may as well not exist.
+- **Rules without artifact:** AGENTS.md references a script that was never created or was deleted. Future agents attempt to invoke a nonexistent tool and waste tokens on errors.
+- **Self-check skipped:** The artifact has a bug that the self-check would have caught. Future agents invoke the broken tool and produce incorrect results. The error propagates into downstream decisions.
+- **Globally scoped rules:** Rules for a narrow-scope tool are placed in the root AGENTS.md. Every agent in the project reads rules that are irrelevant to its task, consuming context window tokens and potentially interfering with behavior.
+- **Catalog not updated:** A new tool is bootstrapped but not added to the Script Catalog section. Future agents scanning for available tools do not find it. The tool exists but is not discoverable.
+- **Boundary documentation missing:** The tool can modify files, but no boundary is documented. A future agent invokes the tool in a context where those modifications are destructive. Explicit boundary documentation ("this tool reads specs/ but never writes to them") prevents misuse.
+
+## Signals & Diagnostics
+
+- **Pattern is needed:** Agents repeatedly build one-off scripts that are never reused; tools built in one session are invisible in the next session; the same capability is rebuilt from scratch in multiple orchestration runs; meta-prompting identifies a "pattern gap" but no pipeline exists to fill it.
+- **Pattern is working:** Every new tool in the project has a corresponding rules section in a scoped AGENTS.md; the Script Catalog grows over time; future agents successfully invoke tools built in prior sessions; self-checks pass after every tool change; the bootstrapping loop produces compound capability across runs.
+- **Pattern is failing:** Tools are created without rules (invisible to future agents); rules reference deleted or renamed tools (broken references); self-checks are skipped and broken tools persist; rules are scoped globally and interfere with unrelated agents; the Script Catalog is stale and does not reflect available tools.
+
+## Tradeoffs
+
+**Gain:** Every new capability is self-documenting, self-verifying, and discoverable by future agents. The agent's skill set compounds across sessions -- each bootstrapping cycle adds a tool that persists. The triple structure (artifact + rules + self-check) prevents the three most common failure modes: invisible tools, broken tools, and undocumented tools. The pattern is the primitive that makes all other compound-learning patterns (meta-prompting, self-reflecting analytics, community pattern mining) possible -- they all require tools that future agents can discover and invoke.
+
+**Cost:** Producing the triple takes more tokens than producing the artifact alone -- roughly 1.5-2x the cost of building just the tool. The rules and self-check are overhead that pays off only when the tool is reused in future sessions. For one-off, never-reused tools, the overhead is wasted. The scoping and cataloging requirements add maintenance burden -- catalogs must be kept current, scopes must be reviewed when directories are restructured.
+
+## Related Patterns
+
+- **self-reflecting-analytics** -- the canonical example of skill bootstrapping applied to observability; the analytics meta-prompt produces the analytics script, the scoped AGENTS.md, and the self-check
+- **meta-prompting** -- identifies capability gaps ("pattern gap: need a tool for X") that skill bootstrapping fills; the two patterns form a discovery-to-implementation pipeline
+- **plugin-architecture** -- in the side-quest-plugins context, each plugin IS a bootstrapped skill (manifest + commands/skills + README); the plugin anatomy mirrors the triple (artifact + rules + documentation)
+- **higher-order-prompt** -- bootstrapped agent definitions extend the HOP by adding new team profiles that the fixed orchestration wrapper can consume without modification
+- **spec-hardening** -- bootstrapped tools should have hardened specifications (concrete inputs, concrete outputs, concrete self-check) following the same rigor applied to task descriptions
+
+## Source Anchors
+
+Community evidence (not yet implemented in orchestrator stages):
+- [From Prompts to AGENTS.md: What Survives Across Thousands of Runs](https://www.youtube.com/watch?v=aMwuPa6BnaM) -- AI Native Dev NYC talk by Tessl; slide: "Give coding agents analytics skills through AGENTS.md -- Leveraging Meta-Prompts to Automatically Build Data Pipelines and Analytics Tools"
+- [Tessl blog post: From Prompts to AGENTS.md](https://tessl.io/blog/from-prompts-to-agents-md-what-survives-across-thousands-of-runs/) -- written companion; three-panel architecture: Meta-Prompt (the seed) -> Analytics Script (the artifact) -> AGENTS.md (the rules)
+- The slide's AGENTS.md shows the exact scoping and contract pattern: version tag (v1), scope declaration, boundary declaration, CLI Contract requirement, Self-Check requirement, Script Catalog
+- Speaker: "We ask it please scan your home directory... build up a script to collect and analyze these traces... not only you can ingest and reflect, but you can collect data"
+- The bootstrapping loop is implicit in the talk's structure: the analytics skill enables the orchestration skill enables the GitHub mining skill -- each cycle builds on the previous
+- [@dani_avila7: Almost 40K downloads across just 3 Claude Code agents](https://x.com/dani_avila7/status/2017096001232781477) (1,441 likes, 138 reposts) -- evidence of skill/agent template distribution at scale via aitmpl.com
+- [@antirez: Claude Code delegating to Codex via skill file](https://x.com/antirez/status/2017314325745086771) (865 likes, 49 reposts) -- practical example of a bootstrapped cross-agent skill
+- [AGENTS.md Files: AI Agent Configuration -- Emergent Mind](https://www.emergentmind.com/topics/agents-md-files) -- median AGENTS.md is ~336 words, ~142 lines, consistent shallow hierarchy; "context debt" concept emerging
+- [Complete Guide to Skills.md in 2026](https://www.flex.com.ph/articles/complete-guide-to-skillsmd-in-2026) -- Skills.md as complementary convention; YAML frontmatter (~100 tokens metadata), full instructions loaded on invocation

--- a/.claude/references/proposed-patterns/pattern-skill-bootstrapping.md
+++ b/.claude/references/proposed-patterns/pattern-skill-bootstrapping.md
@@ -2,6 +2,7 @@
 slug: skill-bootstrapping
 display_name: "Skill Bootstrapping"
 one_liner: "A single meta-prompt that produces both a capability artifact (script, tool, agent) AND the AGENTS.md rules for future agents to use it -- creating a self-bootstrapping loop where each cycle adds compound capability."
+intel_date: 2026-02-26
 slots:
   pattern_id: "## Pattern ID"
   quick_summary: "## Quick Summary"

--- a/.claude/references/proposed-patterns/pattern-three-layer-influence.md
+++ b/.claude/references/proposed-patterns/pattern-three-layer-influence.md
@@ -2,6 +2,7 @@
 slug: three-layer-influence
 display_name: "Three-Layer Influence Model"
 one_liner: "Three layers influence coding agent behavior ordered by durability: system prompts (fragile, changes with each release), AGENTS.md (durable, survives across sessions), and user prompts (volatile, single interaction) -- invest engineering effort in the durable middle layer."
+intel_date: 2026-02-26
 slots:
   pattern_id: "## Pattern ID"
   quick_summary: "## Quick Summary"

--- a/.claude/references/proposed-patterns/pattern-three-layer-influence.md
+++ b/.claude/references/proposed-patterns/pattern-three-layer-influence.md
@@ -1,0 +1,118 @@
+---
+slug: three-layer-influence
+display_name: "Three-Layer Influence Model"
+one_liner: "Three layers influence coding agent behavior ordered by durability: system prompts (fragile, changes with each release), AGENTS.md (durable, survives across sessions), and user prompts (volatile, single interaction) -- invest engineering effort in the durable middle layer."
+slots:
+  pattern_id: "## Pattern ID"
+  quick_summary: "## Quick Summary"
+  when_to_use: "## When To Use"
+  core_mechanism: "## Core Mechanism"
+  key_rules: "## Key Rules"
+  implementation_notes: "## Implementation Notes"
+  failure_modes: "## Failure Modes"
+  signals_diagnostics: "## Signals & Diagnostics"
+  tradeoffs: "## Tradeoffs"
+  related_patterns: "## Related Patterns"
+  source_anchors: "## Source Anchors"
+---
+
+## Pattern ID
+
+three-layer-influence
+
+## Quick Summary
+
+Three layers influence coding agent behavior, ordered by durability: system prompts (fragile, changes with each release), AGENTS.md (durable, survives across sessions), and user prompts (volatile, single interaction). The key insight is that system prompts change nearly every day with new releases, user prompts are ephemeral, and AGENTS.md is the durable middle layer where engineering effort produces compound returns. Referencing Andrej Karpathy's concept of "system prompt learning," the pattern recognizes that investing in the layer outside your control (system prompts) or the layer that disappears after one turn (user prompts) yields poor ROI compared to the persistent middle layer.
+
+## When To Use
+
+- Projects with long lifespans where patterns and learnings should accumulate
+- Teams where multiple engineers interact with the same codebase via AI agents
+- Situations where agent behavior needs to remain consistent across tool updates and model releases
+- When agent behavior needs to be auditable and version-controlled alongside code
+- Projects where onboarding new agents (or new engineers using agents) should be fast and consistent
+
+## Core Mechanism
+
+The three layers exist in a stack, each with different durability characteristics:
+
+**Layer 1: System Prompts (Fragile)**
+- Controlled by the AI tool vendor (Anthropic, OpenAI, etc.)
+- Changes with every model release or tool update
+- Affects behavior and tool usage in ways outside your control
+- Can break existing workflows without warning
+- Cannot be version-controlled or audited by the user
+
+**Layer 2: AGENTS.md (Durable)**
+- Controlled by the project or team
+- Persists across sessions, model releases, and tool updates
+- Version-controlled alongside code
+- Contains rules, skills, and memory
+- Survives agent restarts, context window resets, and model swaps
+- The sweet spot for engineering investment
+
+**Layer 3: User Prompts (Volatile)**
+- Single interaction, single turn
+- Useful for one-off requests or clarifications
+- Can be templated but fundamentally ephemeral
+- Disappears after the agent responds
+- Lowest ROI for effort invested
+
+The model places AGENTS.md at the center because it is the only layer that is both durable (survives across sessions) and controllable (under project ownership).
+
+## Key Rules
+
+1. Invest engineering time in AGENTS.md, not in crafting elaborate user prompts -- user prompts are ephemeral and do not compound.
+2. Do not rely on system prompt behavior to remain stable -- system prompts change with every release and are outside your control.
+3. Extract patterns from successful user prompts and codify them into AGENTS.md -- this converts volatile knowledge into durable knowledge.
+4. Version-control AGENTS.md alongside code -- it is part of the project's executable specification.
+5. When agent behavior changes unexpectedly after a tool update, check if a system prompt change broke an assumption -- update AGENTS.md to compensate.
+6. Template user prompts for common tasks, but do not spend significant time optimizing them -- optimize AGENTS.md instead.
+
+## Implementation Notes
+
+Audit existing workflows to identify patterns currently encoded in user prompts or assumed from system prompt behavior. Migrate these to AGENTS.md:
+
+- **User prompt patterns:** If you repeatedly give the same instruction ("always use named exports"), move it to AGENTS.md.
+- **System prompt assumptions:** If you rely on the agent knowing a specific tool or framework, document it in AGENTS.md so behavior persists across model changes.
+
+Treat AGENTS.md as a living document: update it after every agent run that reveals a gap or learning. This creates a feedback loop where each run improves the next.
+
+When a new model release or tool update changes agent behavior, compare before/after behavior and compensate in AGENTS.md if necessary. This insulates the project from system prompt churn.
+
+Consider creating AGENTS.md templates for common project types (monorepos, libraries, full-stack apps) so new projects start with durable baselines instead of relying on user prompts.
+
+## Failure Modes
+
+- **System prompt dependence:** Workflow relies on specific system prompt behavior. Tool update breaks the workflow because system prompt changed.
+- **Prompt engineering theater:** Engineers spend hours crafting the perfect user prompt for a one-off task instead of updating AGENTS.md with reusable patterns.
+- **Undocumented tribal knowledge:** Experienced engineers know how to prompt the agent effectively, but that knowledge is not captured in AGENTS.md. New engineers or new agents start from zero every time.
+- **Version skew:** AGENTS.md falls out of sync with the codebase. Agents follow outdated rules, causing regressions.
+- **Ignoring layer boundaries:** Treating user prompts as durable (copy-pasting the same prompt repeatedly instead of moving it to AGENTS.md) or treating AGENTS.md as fragile (rewriting it for every new model release instead of letting it stabilize).
+
+## Signals & Diagnostics
+
+- **Pattern is needed:** Agents require lengthy user prompts to produce correct output. Behavior changes unexpectedly after tool updates. New team members struggle to get consistent agent results.
+- **Pattern is working:** User prompts are short and task-specific. Agent behavior remains stable across model releases. AGENTS.md grows steadily as learnings accumulate. New agents (or engineers using agents) onboard quickly by reading AGENTS.md.
+- **Pattern is failing:** Repeated copy-pasting of the same user prompt across multiple sessions. Frequent surprises after tool updates. AGENTS.md is stale or ignored.
+
+## Tradeoffs
+
+**Gain:** Engineering effort compounds -- each update to AGENTS.md improves all future agent runs. Behavior becomes predictable and stable across model releases and tool updates. Knowledge is version-controlled and auditable.
+
+**Cost:** AGENTS.md requires maintenance -- it must be updated as the project evolves. Initial investment needed to extract patterns from user prompts and system assumptions. Risk of over-documenting if AGENTS.md becomes a knowledge dump instead of focused rules.
+
+## Related Patterns
+
+- **Hierarchical Persistent Memory** -- AGENTS.md is the implementation of the durable layer
+- **Meta-Prompting** -- AGENTS.md can contain prompts or prompt fragments for specific scenarios
+- **Spec as Source of Truth** -- validated patterns from completed tasks feed back into AGENTS.md
+- **Skill Bootstrapping** -- AGENTS.md documents skills available to agents
+
+## Source Anchors
+
+- [From Prompts to AGENTS.md: What Survives Across Thousands of Runs](https://www.youtube.com/watch?v=aMwuPa6BnaM) -- AI Native Dev NYC talk by Tessl; speaker references Karpathy's "system prompt learning"
+- [Tessl blog post: From Prompts to AGENTS.md](https://tessl.io/blog/from-prompts-to-agents-md-what-survives-across-thousands-of-runs/)
+- [Evaluating AGENTS.md: Are Repository-Level Context Files Helpful for Coding Agents?](https://arxiv.org/abs/2602.11988) -- ETH Zurich paper; developer-written context files: +4% task success, +19% cost
+- [Effective context engineering for AI agents -- Anthropic Engineering](https://www.anthropic.com/engineering/effective-context-engineering-for-ai-agents) -- "minimum viable context" principle
+- [Stop Using /init for AGENTS.md -- Addy Osmani](https://addyosmani.com/blog/agents-md/) -- "auto-generated content isn't useless, it's redundant"

--- a/.claude/skills/propose-pattern/SKILL.md
+++ b/.claude/skills/propose-pattern/SKILL.md
@@ -1,0 +1,217 @@
+---
+name: propose-pattern
+description: Research and add a new pattern to the proposed-patterns library
+argument-hint: "[pattern name or topic]"
+disable-model-invocation: true
+allowed-tools: Read, Write, Edit, Glob, Grep, Bash(*), Task, Skill
+---
+
+# Propose Pattern
+
+A guided workflow for researching, drafting, and adding a new pattern to the
+proposed-patterns library at `.claude/references/proposed-patterns/`.
+
+This skill performs writes -- it creates a new pattern file. It must not be
+auto-invoked by Claude.
+
+---
+
+## Step 0: Zero-state
+
+If $ARGUMENTS is empty, emit usage and stop:
+
+```
+Propose Pattern -- research and add a new agentic pattern to the library
+
+Usage:
+  /propose-pattern "<pattern name or brief description>"
+
+Examples:
+  /propose-pattern "command vs skill routing"
+  /propose-pattern "arena mode for competitive agent evaluation"
+  /propose-pattern "cooperative refinement between agents"
+
+This will:
+  1. Brainstorm and confirm the pattern with you
+  2. Research source anchors (docs, posts, talks)
+  3. Draft the pattern following the 11-section template
+  4. Review with you before writing the file
+```
+
+## Step 1: Load the template
+
+Read any one existing pattern to use as the structural template:
+
+```
+.claude/references/proposed-patterns/pattern-context-engineering.md
+```
+
+This gives you the exact frontmatter format (slug, display_name, one_liner,
+intel_date, slots) and the 11 required sections. Every new pattern must match
+this structure exactly.
+
+## Step 2: Brainstorm and confirm
+
+Present a brief brainstorm to the user covering:
+
+1. **Proposed slug** -- kebab-case identifier (e.g., `command-vs-skill-routing`)
+2. **Proposed display name** -- human-readable (e.g., "Command vs Skill Routing")
+3. **Draft one-liner** -- single sentence capturing the core insight
+4. **When to use** -- 3-5 bullet points for when this pattern applies
+5. **Related patterns** -- which existing patterns in the library connect to this one
+
+Check existing patterns for overlap:
+
+```bash
+ls .claude/references/proposed-patterns/
+```
+
+If a pattern with a similar slug or topic already exists, flag it. The user
+may want to update the existing pattern instead of creating a new one.
+
+**Do NOT proceed without explicit user confirmation.** The user may want to
+refine the slug, one-liner, or scope before research begins.
+
+## Step 3: Research source anchors
+
+Every pattern needs concrete evidence -- not theoretical speculation.
+
+### 3a: Dispatch newsroom research
+
+Invoke `/newsroom:investigate` to gather engagement-ranked community
+intelligence and web research in a single pass:
+
+```
+/newsroom:investigate "<pattern name>" AND "<related keywords>"
+```
+
+For example, for a pattern about "command vs skill routing":
+```
+/newsroom:investigate "claude code skills" AND "slash commands" AND "SKILL.md"
+```
+
+The newsroom handles the full research pipeline internally:
+- **Reddit, X, YouTube** -- real engagement metrics (upvotes, likes, reposts)
+- **Web search** -- official docs, blog posts, talks (via `--include-web`)
+- **Deduplication and ranking** -- engagement-scored, time-constrained
+
+Extract the highest-signal results as source anchors. Include engagement
+metrics in the anchor description (e.g., "1,441 likes, 138 reposts").
+
+**Source types to prioritize from results:**
+
+1. **Official documentation** -- Anthropic docs, framework docs, API references
+2. **Talks and presentations** -- YouTube links with speaker quotes
+3. **Blog posts** -- from practitioners, framework authors, or companies
+4. **Community discussions** -- Reddit threads, X posts with engagement metrics
+5. **Academic papers** -- arXiv, conference proceedings
+6. **Practical evidence** -- real repos, commits, or PRs that demonstrate the pattern
+
+### 3b: Source quality check
+
+**Minimum:** 3 source anchors. **Target:** 5-7 source anchors.
+**At least 1 must be from community research** (Reddit, X, or YouTube with
+engagement data).
+
+If the newsroom results are thin for this topic, tell the user. A pattern
+with weak evidence should be flagged as speculative in the one-liner or
+Quick Summary.
+
+## Step 4: Draft the pattern
+
+Write the full pattern following the 11-section template exactly:
+
+```yaml
+---
+slug: <kebab-case>
+display_name: "<Human Readable Name>"
+one_liner: "<Single sentence -- the core insight>"
+intel_date: YYYY-MM-DD
+slots:
+  pattern_id: "## Pattern ID"
+  quick_summary: "## Quick Summary"
+  when_to_use: "## When To Use"
+  core_mechanism: "## Core Mechanism"
+  key_rules: "## Key Rules"
+  implementation_notes: "## Implementation Notes"
+  failure_modes: "## Failure Modes"
+  signals_diagnostics: "## Signals & Diagnostics"
+  tradeoffs: "## Tradeoffs"
+  related_patterns: "## Related Patterns"
+  source_anchors: "## Source Anchors"
+---
+```
+
+**Section guidelines:**
+
+| Section | What to write | Common mistakes |
+|---------|--------------|-----------------|
+| Quick Summary | 1-2 paragraphs explaining the pattern. Lead with the core insight. | Too abstract -- ground it in concrete mechanism |
+| When To Use | Bullet list of specific situations | Too vague -- "when you need better code" is not useful |
+| Core Mechanism | The how -- concrete steps, diagrams, code examples | Missing the mechanism -- describing outcomes not process |
+| Key Rules | Numbered list of non-negotiable constraints | Rules that are actually preferences, not constraints |
+| Implementation Notes | Practical details, interactions with other patterns | Over-engineering -- keep it grounded in what exists |
+| Failure Modes | Bullet list of what goes wrong and why | Only listing obvious failures -- dig into subtle ones |
+| Signals & Diagnostics | Three sub-bullets: needed, working, failing | Signals that are impossible to observe |
+| Tradeoffs | Gain paragraph, Cost paragraph | Listing only gains -- every pattern has real costs |
+| Related Patterns | Bullet list with slug and relationship description | Listing unrelated patterns for completeness |
+| Source Anchors | Bullet list with URLs and evidence descriptions | Broken links, missing descriptions, no direct quotes |
+
+**Writing style:**
+- Technical and precise -- explain the "why" not just the "what"
+- No em dashes (use -- double hyphens instead)
+- Concrete examples over abstract descriptions
+- Direct quotes from sources where available
+
+## Step 5: Review with user
+
+Present the complete draft to the user. Highlight:
+
+- The one-liner (most important -- sets the frame for the whole pattern)
+- Source anchors (are they strong enough?)
+- Related patterns (did we miss connections?)
+
+**Do NOT write the file without explicit user approval.**
+
+The user may want to:
+- Refine the one-liner
+- Add or remove source anchors
+- Adjust the scope (too broad? too narrow?)
+- Merge with an existing pattern instead
+
+## Step 6: Write the file
+
+Once approved, write the pattern file:
+
+```
+.claude/references/proposed-patterns/pattern-<slug>.md
+```
+
+**Filename convention:** `pattern-` prefix + slug + `.md`
+
+Verify the file was created:
+
+```bash
+ls -la .claude/references/proposed-patterns/pattern-<slug>.md
+```
+
+Report the final file path and pattern count:
+
+```bash
+ls .claude/references/proposed-patterns/ | wc -l
+```
+
+---
+
+## Quality Checklist
+
+Before writing the file, verify:
+
+- [ ] Frontmatter has all required fields (slug, display_name, one_liner, intel_date, slots)
+- [ ] All 11 sections are present with correct headings
+- [ ] Slug matches the filename (`pattern-<slug>.md`)
+- [ ] One-liner is a single sentence (not a paragraph)
+- [ ] Source anchors have working URLs and evidence descriptions
+- [ ] Related patterns reference slugs that exist in the library
+- [ ] No em dashes (-- only)
+- [ ] User explicitly approved the draft

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# HOP Orchestrator - Learn Agent Orchestration Patterns
+# My Agent Dojo - Learn Agent Orchestration Patterns
 
 Each branch is a standalone lesson. Checkout any stage to see the
 orchestrator at that complexity level.
@@ -20,7 +20,7 @@ orchestrator at that complexity level.
 ## Quick Start
 
 ```
-git clone https://github.com/nathanvale/orchestrator-prototype
+git clone https://github.com/nathanvale/my-agent-dojo
 git checkout orchestration/1-dispatch    # Start here
 # Run: /orchestrate "add a greet function"
 ```

--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
-	"name": "orchestrator-prototype",
+	"name": "my-agent-dojo",
 	"version": "0.0.0",
 	"private": true,
-	"description": "HOP Orchestrator prototype - learn agent orchestration patterns incrementally",
+	"description": "My Agent Dojo - learn agent orchestration patterns incrementally",
 	"author": {
 		"name": "Nathan Vale",
 		"url": "https://github.com/nathanvale"
@@ -11,12 +11,12 @@
 	"type": "module",
 	"repository": {
 		"type": "git",
-		"url": "git+https://github.com/nathanvale/orchestrator-prototype.git"
+		"url": "git+https://github.com/nathanvale/my-agent-dojo.git"
 	},
 	"bugs": {
-		"url": "https://github.com/nathanvale/orchestrator-prototype/issues"
+		"url": "https://github.com/nathanvale/my-agent-dojo/issues"
 	},
-	"homepage": "https://github.com/nathanvale/orchestrator-prototype#readme",
+	"homepage": "https://github.com/nathanvale/my-agent-dojo#readme",
 	"keywords": [
 		"typescript",
 		"bun",


### PR DESCRIPTION
## Summary
- Adds `.claude/references/proposed-patterns/` directory with 13 new pattern files
- These are candidate patterns for evaluation before promotion to the main catalog
- All follow the 11-slot frontmatter contract

## Proposed Patterns
- arena-mode
- community-pattern-mining
- context-engineering
- cooperative-refinement
- hierarchical-persistent-memory
- lifecycle-memory-checkpoints
- meta-prompting
- no-fake-no-mock
- prompt-hop-chain-reduction
- rules-as-exploration-enablers
- self-reflecting-analytics
- skill-bootstrapping
- three-layer-influence

## Test plan
- [ ] Verify all 13 files exist under `.claude/references/proposed-patterns/`
- [ ] Confirm each file has valid 11-slot frontmatter
- [ ] Ensure no changes to existing `.claude/references/patterns/` directory

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added many new pattern specifications (Arena Mode, Community Pattern Mining, Context Engineering, Cooperative Refinement, Hierarchical Persistent Memory, Lifecycle Memory Checkpoints, Meta‑Prompting, No‑Fake/No‑Mock, Prompt Hop Chain Reduction, Rules as Exploration Enablers, Self‑Reflecting Analytics, Skill Bootstrapping, Three‑Layer Influence, Agent‑Hint Observability, Command vs Skill Routing, and others). Updated pattern metadata and central docs (CLAUDE.md, patterns index, README).
* **Chores**
  * Project identity updated to "My Agent Dojo" (package metadata, README) and added a guided skill for proposing patterns.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->